### PR TITLE
Fix issue with gnmi_cli and forwarding pipeline

### DIFF
--- a/Documentation/howto/ovs-with-p4-executables.rst
+++ b/Documentation/howto/ovs-with-p4-executables.rst
@@ -223,3 +223,11 @@ previously configured CONFIG params.
     sub-node which holds multiple ports like net_vhost0, net_vhost1,... Pass
     the key name for whose value need to be fetched. Each get can take ONLY
     one key, and fetches value for that previously configured KEY.
+
+.. important::
+  If grpc connection to server fails, export GRPC_TRACE=all and check if any
+  proxy errors are encountered. If Yes, then configure localhost as an entry in
+  NO_PROXY environmental variable (append localhost if NO_PROXY is already
+  configured).
+
+  Example: export NO_PROXY=localhost,127.0.0.1

--- a/p4proto/p4rt/p4_service.cc
+++ b/p4proto/p4rt/p4_service.cc
@@ -389,6 +389,16 @@ void LogReadRequest(uint64 node_id, const ::p4::v1::ReadRequest& req,
                        node_id, "."));
     }
 
+    // FIXME: We are not supporting overwrite of an already configured pipeline
+    // for a single device. Remove this check when support for overwriting an
+    // already configured forwarding pipeline is available.
+    if (forwarding_pipeline_configs_ != nullptr &&
+          forwarding_pipeline_configs_->node_id_to_config_size() != 0) {
+        return ::grpc::Status(::grpc::StatusCode::FAILED_PRECONDITION,
+                              "Only a single forwarding pipeline can be pushed "
+                              "for any node so far.");
+    }
+
     ::util::Status status = ::util::OkStatus();
     switch (req->action()) {
       case ::p4::v1::SetForwardingPipelineConfigRequest::VERIFY:

--- a/utilities/gnmi_cli.cc
+++ b/utilities/gnmi_cli.cc
@@ -55,7 +55,9 @@ example:
 
 #define MAX_STR_LENGTH 128
 
-DEFINE_string(grpc_addr, "0.0.0.0:9339", "gNMI server address");
+// FIXME: For now it is connecting to localhost and later it has to be fixed
+// to support any host, by providing an CLI options to the user.
+DEFINE_string(grpc_addr, "127.0.0.1:9339", "gNMI server address");
 
 DEFINE_uint64(interval, 5000, "Subscribe poll interval in ms");
 DEFINE_bool(replace, false, "Use replace instead of update");


### PR DESCRIPTION
- On few machines, it is observed that gnmi_cli is not connecting to
  grpc server, this is due to proxy issues for 0.0.0.0 IP address.
  Modified gnmi_cli to use 127.0.0.1 and updated document regarding the same.
- When forwaring pipeline is set more than once for the same device, we see an
  issue. Since we are not supporting multiple forwarding pipelines, for now
  we error out if user tries to configure pipeline more than once.

Change-type: DefectResolution
Title: Fix issue with gnmi_cli and forwarding pipeline
Signed-off-by: n-sandeep <sandeep.nagapattinam@intel.com>