### PR TITLE
p4ovs: Add lib64 to LD_LIBRARY_PATH

### DIFF
--- a/p4ovs_env_setup.sh
+++ b/p4ovs_env_setup.sh
@@ -32,6 +32,7 @@ echo "OS and Version details..."
 echo "$OS : $VER"
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib64
 
 #Dependencies needed for building netlink library
 if [[ $OS =~ "Fedora" ]]; then


### PR DESCRIPTION
Needed when building on bare metal or in a VM.

Signed-off-by: Kyle Mestery <mestery@mestery.com>