### PR TITLE
os_ver_details: fix shebang line

### DIFF
--- a/os_ver_details.sh
+++ b/os_ver_details.sh
@@ -1,3 +1,4 @@
+#! /bin/bash
 # Copyright (c) 2021 Intel Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#! /bin/bash
-set -e
 
 get_os_ver_details()
 {


### PR DESCRIPTION
The shebang line should be the first line in the file.

The `set -e` option instructs bash to immediately exit if any command has a non-zero exit status. However, there are several conditional checks that have a non-zero exit status may result in this script terminating unexpectedly.