### PR TITLE
P4-OVS: Fix issue 82

### DIFF
--- a/install_dep_packages.sh
+++ b/install_dep_packages.sh
@@ -64,9 +64,9 @@ echo "Number of Parallel threads used: $NUM_THREADS ..."
 echo ""
 
 # Dependencies needed for building netlink library
-if [ "$OS" == "Fedora" ]; then
+if [ "$OS" = "Fedora" ]; then
     sudo dnf install -y pkgconfig libnl3-devel
-elif [ "$OS" == "Ubuntu" ]; then
+elif [ "$OS" = "Ubuntu" ]; then
     sudo apt-get install -y pkg-config libnl-route-3-dev
 else
     sudo yum install -y pkgconfig libnl3-devel
@@ -149,7 +149,7 @@ git clone https://github.com/google/grpc.git "$SRC_DIR"/"$MODULE"
 cd "$SRC_DIR"/"$MODULE"
 git checkout tags/v1.17.2
 git submodule update --init --recursive
-if [[ $OS =~ "Fedora" ]];
+if [ $OS = "Fedora" ];
 then
    git apply "$WS_DIR"/external/PATCH-01-GRPC
 fi

--- a/p4ovs_env_setup.sh
+++ b/p4ovs_env_setup.sh
@@ -35,7 +35,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib64
 
 #Dependencies needed for building netlink library
-if [[ $OS =~ "Fedora" ]]; then
+if [ $OS = "Fedora" ]; then
     export PKG_CONFIG_PATH=${SDE_INSTALL}/lib64/pkgconfig
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SDE_INSTALL/lib64
 else


### PR DESCRIPTION
On older bash versions == operator doesn't work with [..] operator.
Due to this, depending on bash versions on your system,
install_dep_packages.sh script which install gflags and other
important dependencies will not run and you will run into packages
missing issue

Title: Fix issue 82
Change-type: DefectResolution
Signed-off-by: Nupur Uttarwar <nupur.uttarwar@intel.com>