### PR TITLE
Update P4 file to vlidate header before adding content

### DIFF
--- a/Documentation/howto/ovs-with-p4-executables.rst
+++ b/Documentation/howto/ovs-with-p4-executables.rst
@@ -663,6 +663,9 @@ Limitations/Note
     disable checksum using below command.
     $ ethtool --offload <netdev-name> rx off tx off
 
+    d) pna_tcp_connection_tracking demonstrates the PNA add_on_miss feature and
+    flow aging for auto learn flows. It supports basic TCP CT state machine.
+
 
 Logs and Analysis
 ------------------


### PR DESCRIPTION
> As per recent changes in DPDK target, the correct procedure is
to validate header before adding/updating contents to the header.
This review modifies the p4 file to address this.
> Remove un-used actions for a table.
> Update document to capture pna_tcp_connection_tracking p4 file usecases.

Signed-off-by: n-sandeep <sandeep.nagapattinam@intel.com>