### PR TITLE
Fix readme links in parent readme

### DIFF
--- a/p4proto/kctrl/README.md
+++ b/p4proto/kctrl/README.md
@@ -28,4 +28,5 @@ Switchapi layer. p4proto/kctrl directory contains the code to manage kernel inte
 - [Switchlink](/p4proto/kctrl/switchlink/README.md)
 - [SwitchSAI](/p4proto/kctrl/switchsai/README.md)
 - [Switchapi](/p4proto/kctrl/switchapi/README.md)
-- [Linux Networking usecase](/p4proto/p4src/linux_networking/README.md)
+- [Linux Networking usecase](/p4proto/p4src/linux_networking/README_LINUX_NETWORKING.md)
+- [Linux Networking with ECMP usecase](/p4proto/p4src/linux_networking/README_LINUX_NETWORKING_WITH_ECMP.md)


### PR DESCRIPTION
Fix readme link for linux networking and
linux networking with ecmp usecase

Title: Fix readme links in parent readme
Signed-off-by: nupuruttarwar <nupur.uttarwar@intel.com>