### PR TITLE
l2l3_config_invalid_params

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -194,8 +194,8 @@ EXTRA_DIST = \
 	ptf_tests/common/config/lnt_2vm_vxlan_2nsvm_5min_ping.json \
 	ptf_tests/common/config/lnt_1hotplugvm_vxlan_1nsvm.json \
 	ptf_tests/common/config/config_control_port_with_link.json \
-    ptf_tests/common/config/l2l3_unsupport_tbl_port_match_action.json \
-    ptf_tests/common/config/l2l3_unsupport_tbl_port_proto_action.json \
+        ptf_tests/common/config/l2l3_unsupport_tbl_port_match_action.json \
+        ptf_tests/common/config/l2l3_unsupport_tbl_port_proto_action.json \
 	ptf_tests/common/p4c_artifacts/l3_action_profile/l3_action_profile.p4 \
 	ptf_tests/common/p4c_artifacts/l3_action_profile/l3_action_profile.conf \
 	ptf_tests/common/p4c_artifacts/l3_action_selector/l3_action_selector.p4 \
@@ -267,8 +267,8 @@ EXTRA_DIST = \
 	ptf_tests/tests/lnt_2vm_vxlan_2nsvm_5min_ping.py \
 	ptf_tests/tests/lnt_1hotplugvm_vxlan_1nsvm.py \
 	ptf_tests/tests/config_control_port_with_link.py \
-    ptf_tests/tests/l2l3_unsupport_tbl_port_match_action.py \
-    ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py \
+        ptf_tests/tests/l2l3_unsupport_tbl_port_match_action.py \
+        ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py \
 	ptf_tests/common/lib/tcpdump.py \
 	ptf_tests/common/utils/tcpdump_utils.py \
 	ptf_tests/tests/mtu_config_test_with_tap.py \

--- a/Makefile.am
+++ b/Makefile.am
@@ -194,6 +194,8 @@ EXTRA_DIST = \
 	ptf_tests/common/config/lnt_2vm_vxlan_2nsvm_5min_ping.json \
 	ptf_tests/common/config/lnt_1hotplugvm_vxlan_1nsvm.json \
 	ptf_tests/common/config/config_control_port_with_link.json \
+    ptf_tests/common/config/l2l3_unsupport_tbl_port_match_action.json \
+    ptf_tests/common/config/l2l3_unsupport_tbl_port_proto_action.json \
 	ptf_tests/common/p4c_artifacts/l3_action_profile/l3_action_profile.p4 \
 	ptf_tests/common/p4c_artifacts/l3_action_profile/l3_action_profile.conf \
 	ptf_tests/common/p4c_artifacts/l3_action_selector/l3_action_selector.p4 \
@@ -265,6 +267,8 @@ EXTRA_DIST = \
 	ptf_tests/tests/lnt_2vm_vxlan_2nsvm_5min_ping.py \
 	ptf_tests/tests/lnt_1hotplugvm_vxlan_1nsvm.py \
 	ptf_tests/tests/config_control_port_with_link.py \
+    ptf_tests/tests/l2l3_unsupport_tbl_port_match_action.py \
+    ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py \
 	ptf_tests/common/lib/tcpdump.py \
 	ptf_tests/common/utils/tcpdump_utils.py \
 	ptf_tests/tests/mtu_config_test_with_tap.py \

--- a/ptf_tests/common/config/l2l3_unsupport_tbl_port_match_action.json
+++ b/ptf_tests/common/config/l2l3_unsupport_tbl_port_match_action.json
@@ -1,0 +1,91 @@
+{
+    "switch": "br0",
+    "p4file": "l3_exact_match",
+    "port": [
+        {
+            "id": "1",
+            "device": "virtual-device",
+            "name": "TAP0",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE",
+            "mac": "00:00:01:00:00:01"
+        },
+        {
+            "id": "2",
+            "device": "virtual-device",
+            "name": "TAP1",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE",
+            "mac": "00:00:01:00:00:02"
+        },
+        {
+            "id": "3",
+            "device": "virtual-device",
+            "name": "TAP2",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE"
+        },
+        {
+            "id": "4",
+            "device": "virtual-device",
+            "name": "TAP3",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE"
+        }
+    ],
+    "table": [
+        {
+            "description": "Unsupport tabel, ports, match field and actions",
+            "switch": "br0",
+            "name": "pipe.ipv4_host",
+            "type": "entry",
+            "match_action": [
+                "hdr.ipv4.dst_addr=1.1.1.1,action=send(X)",
+                "headers.ipv4.dst_addr=1.1.1.2,action=ingress.drop(1)",
+                "hdr.ipv4.l2_addr=1.1.1.1,action=send(0)",
+                "hdr.ipv4.dst_addr=1.1.1.1,action=mirror(0)"
+            ]
+        },
+        {
+            "description": "Support table_for_dst_ip",
+            "switch": "br0",
+            "name": "ingress.ipv4_host_dst",
+            "type": "entry",
+            "match_action": [
+                "headers.ipv4.dst_addr=1.1.1.2,action=ingress.send(0)",
+                "headers.ipv4.dst_addr=2.2.2.3,action=ingress.send(1)"
+            ]
+        }
+    ],
+    "traffic": {
+        "type": "tcp",
+        "pkt_num": 50,
+        "send_port": [
+            1,
+            2
+        ],
+        "receive_port": [
+            0,
+            1
+        ],
+        "ip_dst": [
+            "1.1.1.2",
+            "2.2.2.3"
+        ],
+        "ip_src": [
+            "192.168.1.10"
+        ]
+    }
+}

--- a/ptf_tests/common/config/l2l3_unsupport_tbl_port_proto_action.json
+++ b/ptf_tests/common/config/l2l3_unsupport_tbl_port_proto_action.json
@@ -1,0 +1,98 @@
+{
+    "switch": "br0",
+    "p4file": "l3_exact_match",
+    "port": [
+        {
+            "id": "1",
+            "device": "virtual-device",
+            "name": "TAP0",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE",
+            "mac": "00:00:01:00:00:01"
+        },
+        {
+            "id": "2",
+            "device": "virtual-device",
+            "name": "TAP1",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE",
+            "mac": "00:00:01:00:00:02"
+        },
+        {
+            "id": "3",
+            "device": "virtual-device",
+            "name": "TAP2",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE"
+        },
+        {
+            "id": "4",
+            "device": "virtual-device",
+            "name": "TAP3",
+            "port-type": "TAP",
+            "pipeline-name": "pipe",
+            "mempool-name": "MEMPOOL0",
+            "mtu": "1500",
+            "single-cmd": "TRUE"
+        }
+    ],
+    "table": [
+        {
+            "description": "Unsupport port and action",
+            "switch": "br0",
+            "name": "pipe.ipv4_host",
+            "type": "entry",
+            "match_action": [
+                "hdr.ipv4.dst_addr=1.1.1.1,action=send(10)",
+                "hdr.ipv4.dst_addr=1.1.1.1,action=resubmit(1)"
+            ]
+        },
+        {
+            "description": "Unsupport proto",
+            "switch": "br0",
+            "name": "pipe.ipv6_host",
+            "type": "entry",
+            "match_action": [
+                "hdr.ipv6.dst_addr=1.1.1.1,action=send(1)"
+            ]
+        },
+        {
+            "description": "Support table_for_dst_ip",
+            "switch": "br0",
+            "name": "ingress.ipv4_host_dst",
+            "type": "entry",
+            "match_action": [
+                "headers.ipv4.dst_addr=1.1.1.2,action=ingress.send(0)",
+                "headers.ipv4.dst_addr=2.2.2.3,action=ingress.send(1)"
+            ]
+        }
+    ],
+    "traffic": {
+        "type": "tcp",
+        "pkt_num": 50,
+        "send_port": [
+            1,
+            2
+        ],
+        "receive_port": [
+            0,
+            1
+        ],
+        "ip_dst": [
+            "1.1.1.2",
+            "2.2.2.3"
+        ],
+        "ip_src": [
+            "192.168.1.10"
+        ]
+    }
+}

--- a/ptf_tests/tests/l2l3_unsupport_tbl_port_match_action.py
+++ b/ptf_tests/tests/l2l3_unsupport_tbl_port_match_action.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2022 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+DPDK L2 L3 Configure Unsupport table, ports, match fields and actions
+"""
+
+# in-built module imports
+import time
+import sys
+
+# Unittest related imports
+import unittest
+
+# ptf related imports
+import ptf
+import ptf.dataplane as dataplane
+from ptf.base_tests import BaseTest
+from ptf.testutils import *
+from ptf import config
+
+# framework related imports
+import common.utils.ovsp4ctl_utils as ovs_p4ctl
+import common.utils.test_utils as test_utils
+from common.utils.config_file_utils import get_config_dict, get_gnmi_params_simple, get_interface_ipv4_dict
+from common.utils.gnmi_cli_utils import gnmi_cli_set_and_verify, gnmi_set_params, ip_set_ipv4, gnmi_get_params_counter
+
+
+class L2L3_Unpsupport_Tbl_Port_Match_Action(BaseTest):
+
+    def setUp(self):
+        BaseTest.setUp(self)
+        self.result = unittest.TestResult()
+        config["relax"] = True # for verify_packets to ignore other packets received at the interface
+        
+        test_params = test_params_get()
+        config_json = test_params['config_json']
+        self.dataplane = ptf.dataplane_instance
+        ptf.dataplane_instance = ptf.dataplane.DataPlane(config)
+
+        self.config_data = get_config_dict(config_json)
+
+        self.gnmicli_params = get_gnmi_params_simple(self.config_data)
+        self.interface_ip_list = get_interface_ipv4_dict(self.config_data)
+
+
+    def runTest(self):
+        if not test_utils.gen_dep_files_p4c_ovs_pipeline_builder(self.config_data):
+            self.result.addFailure(self, sys.exc_info())
+            self.fail("Failed to generate P4C artifacts or pb.bin")
+
+        if not gnmi_cli_set_and_verify(self.gnmicli_params):
+            self.result.addFailure(self, sys.exc_info())
+            self.fail("Failed to configure gnmi cli ports")
+
+        ip_set_ipv4(self.interface_ip_list)
+
+        port_list = self.config_data['port_list']
+        port_ids = test_utils.add_port_to_dataplane(port_list)
+
+        for port_id, ifname in config["port_map"].items():
+            device, port = port_id
+            self.dataplane.port_add(ifname, device, port)
+
+        if not ovs_p4ctl.ovs_p4ctl_set_pipe(self.config_data['switch'], self.config_data['pb_bin'], self.config_data['p4_info']):
+            self.result.addFailure(self, sys.exc_info())
+            self.fail("Failed to set pipe")
+        
+      
+        for table in self.config_data['table']:
+            print(f"Scenario : {table['description']}")
+            print(f"Adding {table['description']} rules")
+            if table['name'] == "pipe.ipv4_host":
+                for match_action in table['match_action']:
+                    if ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
+                        self.result.addFailure(self, sys.exc_info())
+                        self.fail(f"Failed: invalid entry {match_action} should not be added")
+                    print (f"EXPECTED failure to add Invalid match action {match_action}")
+            elif table['name'] == "ingress.ipv4_host_dst":
+                for match_action in table['match_action']:
+                    if not ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
+                        self.result.addFailure(self, sys.exc_info())
+                        self.fail(f"Failed to add table entry {match_action}")
+
+        print (f"Sending Traffic")
+        # Verify support table, ports and match actions
+        for table in self.config_data['table'][1:2]:
+            for i in range(len(table['match_action'])):
+                print (f"Verifing match action {table['match_action'][i]}") 
+                pkt = simple_tcp_packet(ip_src = self.config_data['traffic']['ip_src'][0],
+                                          ip_dst=self.config_data['traffic']['ip_dst'][i])
+                send_packet(self, port_ids[self.config_data['traffic']['send_port'][i]],
+                                          pkt, count= self.config_data['traffic']['pkt_num'])
+                try:
+                    verify_packet(self, pkt, port_ids[self.config_data['traffic']['receive_port'][i]][1])
+                    print(f"PASS: Verification of packets passed, packet received as per rule {i+1}")
+                except Exception as err:
+                    self.result.addFailure(self, sys.exc_info())
+                    print(f"FAIL: Verification of packets sent failed with exception {err}")
+                    
+        self.dataplane.kill()
+
+    def tearDown(self):
+
+        for table in self.config_data['table']:
+            if table['name'] == "ingress.ipv4_host_src":
+                print(f"Deleting {table['description']} rules")
+                for del_action in table['del_action']:
+                    ovs_p4ctl.ovs_p4ctl_del_entry(table['switch'], table['name'], del_action)
+         
+        if self.result.wasSuccessful():
+            print("Test has PASSED")
+        else:
+            print("Test has FAILED")

--- a/ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py
+++ b/ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 Intel Corporation.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py
+++ b/ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py
@@ -86,40 +86,41 @@ class L2L3_Unsupport_tbl_port_proto_action(BaseTest):
                     if ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
                         self.result.addFailure(self, sys.exc_info())
                         self.fail(f"Failed: invalid entry {match_action} should not be added")
-                    print (f"EXPECTED failure to add Invalid match action {match_action}")
+                    print (f"PASS: expected failure to add Invalid match action {match_action}")
             if table['name'] == "pipe.ipv6_host":
                 for match_action in table['match_action']:
                     if ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
                         self.result.addFailure(self, sys.exc_info())
-                        self.fail(f"Failed: invalid entry {match_action} should not be added")       
+                        self.fail(f"Failed: invalid entry {match_action} should not be added") 
+                    print (f"PASS: expected failure to add Invalid match action {match_action}")      
             elif table['name'] == "ingress.ipv4_host_dst":
+                #add supported proto
                 for match_action in table['match_action']:
                     if not ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
                         self.result.addFailure(self, sys.exc_info())
                         self.fail(f"Failed to add table entry {match_action}")
-
+    
         print (f"Sending Traffic")
         # Verify support table, ports, proto, actions
-        for table in self.config_data['table'][2:3]:
-            for i in range(len(table['match_action'])):
-                print (f"Verifing match action {table['match_action'][i]}") 
-                pkt = simple_tcp_packet(ip_src = self.config_data['traffic']['ip_src'][0],
-                                          ip_dst=self.config_data['traffic']['ip_dst'][i])
-                send_packet(self, port_ids[self.config_data['traffic']['send_port'][i]],
-                                          pkt, count= self.config_data['traffic']['pkt_num'])
-                try:
-                    verify_packet(self, pkt, port_ids[self.config_data['traffic']['receive_port'][i]][1])
-                    print(f"PASS: Verification of packets passed, packet received as per rule {i+1}")
-                except Exception as err:
-                    self.result.addFailure(self, sys.exc_info())
-                    print(f"FAIL: Verification of packets sent failed with exception {err}")
-                
+        for i in range(len(self.config_data['table'][2]['match_action'])):
+            print (f"Verifing match action {table['match_action'][i]}") 
+            pkt = simple_tcp_packet(ip_src = self.config_data['traffic']['ip_src'][0],
+                                        ip_dst=self.config_data['traffic']['ip_dst'][i])
+            send_packet(self, port_ids[self.config_data['traffic']['send_port'][i]],
+                                        pkt, count= self.config_data['traffic']['pkt_num'])
+            try:
+                verify_packet(self, pkt, port_ids[self.config_data['traffic']['receive_port'][i]][1])
+                print(f"PASS: Verification of packets passed, packet received as per rule {i+1}")
+            except Exception as err:
+                self.result.addFailure(self, sys.exc_info())
+                print(f"FAIL: Verification of packets sent failed with exception {err}")
+            
         self.dataplane.kill()
 
     def tearDown(self):
 
         for table in self.config_data['table']:
-            if table['name'] == "ingress.ipv4_host_src":
+            if table['name'] == "ingress.ipv4_host_dst":
                 print(f"Deleting {table['description']} rules")
                 for del_action in table['del_action']:
                     ovs_p4ctl.ovs_p4ctl_del_entry(table['switch'], table['name'], del_action)

--- a/ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py
+++ b/ptf_tests/tests/l2l3_unsupport_tbl_port_proto_action.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2022 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+DPDK L2 L3 Configure unsupport table, ports, proto, actions
+"""
+
+# in-built module imports
+import time
+import sys
+
+# Unittest related imports
+import unittest
+
+# ptf related imports
+import ptf
+import ptf.dataplane as dataplane
+from ptf.base_tests import BaseTest
+from ptf.testutils import *
+from ptf import config
+
+# framework related imports
+import common.utils.ovsp4ctl_utils as ovs_p4ctl
+import common.utils.test_utils as test_utils
+from common.utils.config_file_utils import get_config_dict, get_gnmi_params_simple, get_interface_ipv4_dict
+from common.utils.gnmi_cli_utils import gnmi_cli_set_and_verify, gnmi_set_params, ip_set_ipv4, gnmi_get_params_counter
+
+
+class L2L3_Unsupport_tbl_port_proto_action(BaseTest):
+
+    def setUp(self):
+        BaseTest.setUp(self)
+        self.result = unittest.TestResult()
+        config["relax"] = True # for verify_packets to ignore other packets received at the interface
+        
+        test_params = test_params_get()
+        config_json = test_params['config_json']
+        self.dataplane = ptf.dataplane_instance
+        ptf.dataplane_instance = ptf.dataplane.DataPlane(config)
+
+        self.config_data = get_config_dict(config_json)
+
+        self.gnmicli_params = get_gnmi_params_simple(self.config_data)
+        self.interface_ip_list = get_interface_ipv4_dict(self.config_data)
+
+
+    def runTest(self):
+        if not test_utils.gen_dep_files_p4c_ovs_pipeline_builder(self.config_data):
+            self.result.addFailure(self, sys.exc_info())
+            self.fail("Failed to generate P4C artifacts or pb.bin")
+
+        if not gnmi_cli_set_and_verify(self.gnmicli_params):
+            self.result.addFailure(self, sys.exc_info())
+            self.fail("Failed to configure gnmi cli ports")
+
+        ip_set_ipv4(self.interface_ip_list)
+
+        port_list = self.config_data['port_list']
+        port_ids = test_utils.add_port_to_dataplane(port_list)
+
+        for port_id, ifname in config["port_map"].items():
+            device, port = port_id
+            self.dataplane.port_add(ifname, device, port)
+
+        if not ovs_p4ctl.ovs_p4ctl_set_pipe(self.config_data['switch'], self.config_data['pb_bin'], self.config_data['p4_info']):
+            self.result.addFailure(self, sys.exc_info())
+            self.fail("Failed to set pipe")
+        
+        for table in self.config_data['table']:
+            print(f"Scenario : {table['description']}")
+            print(f"Adding {table['description']} rules")
+            if table['name'] == "pipe.ipv4_host":
+                for match_action in table['match_action']:
+                    if ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
+                        self.result.addFailure(self, sys.exc_info())
+                        self.fail(f"Failed: invalid entry {match_action} should not be added")
+                    print (f"EXPECTED failure to add Invalid match action {match_action}")
+            if table['name'] == "pipe.ipv6_host":
+                for match_action in table['match_action']:
+                    if ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
+                        self.result.addFailure(self, sys.exc_info())
+                        self.fail(f"Failed: invalid entry {match_action} should not be added")       
+            elif table['name'] == "ingress.ipv4_host_dst":
+                for match_action in table['match_action']:
+                    if not ovs_p4ctl.ovs_p4ctl_add_entry(table['switch'],table['name'], match_action):
+                        self.result.addFailure(self, sys.exc_info())
+                        self.fail(f"Failed to add table entry {match_action}")
+
+        print (f"Sending Traffic")
+        # Verify support table, ports, proto, actions
+        for table in self.config_data['table'][2:3]:
+            for i in range(len(table['match_action'])):
+                print (f"Verifing match action {table['match_action'][i]}") 
+                pkt = simple_tcp_packet(ip_src = self.config_data['traffic']['ip_src'][0],
+                                          ip_dst=self.config_data['traffic']['ip_dst'][i])
+                send_packet(self, port_ids[self.config_data['traffic']['send_port'][i]],
+                                          pkt, count= self.config_data['traffic']['pkt_num'])
+                try:
+                    verify_packet(self, pkt, port_ids[self.config_data['traffic']['receive_port'][i]][1])
+                    print(f"PASS: Verification of packets passed, packet received as per rule {i+1}")
+                except Exception as err:
+                    self.result.addFailure(self, sys.exc_info())
+                    print(f"FAIL: Verification of packets sent failed with exception {err}")
+                
+        self.dataplane.kill()
+
+    def tearDown(self):
+
+        for table in self.config_data['table']:
+            if table['name'] == "ingress.ipv4_host_src":
+                print(f"Deleting {table['description']} rules")
+                for del_action in table['del_action']:
+                    ovs_p4ctl.ovs_p4ctl_del_entry(table['switch'], table['name'], del_action)
+         
+        if self.result.wasSuccessful():
+            print("Test has PASSED")
+        else:
+            print("Test has FAILED")

--- a/ptf_tests/tests_to_run.txt
+++ b/ptf_tests/tests_to_run.txt
@@ -43,3 +43,5 @@ lnt_4vm_2host_add_dele_rule:config_json='lnt_4vm_2host_add_dele_rule.json';vm_lo
 lnt_2vm_vxlan_2nsvm_5min_ping:config_json='lnt_2vm_vxlan_2nsvm_5min_ping.json';vm_location_list='VM1,VM2';pci_bdf='BDF1,BDF2';remote_port='PORT1';client_cred='CLIENT'
 lnt_1hotplugvm_vxlan_1nsvm:config_json='lnt_1hotplugvm_vxlan_1nsvm.json';vm_location_list='VM1';pci_bdf='BDF1';remote_port='PORT1';client_cred='CLIENT'
 lnt_2hotplugvm_vxlan_2nsvm:config_json='lnt_2hotplugvm_vxlan_2nsvm.json';vm_location_list='VM1,VM2';pci_bdf='BDF1,BDF2';remote_port='PORT1';client_cred='CLIENT'
+l2l3_unsupport_tbl_port_match_action:config_json='l2l3_unsupport_tbl_port_match_action.json'
+l2l3_unsupport_tbl_port_proto_action:config_json='l2l3_unsupport_tbl_port_proto_action.json'


### PR DESCRIPTION
Signed-off-by: Hiren Thakkar <hiren.thakkar@intel.com>

This PR is to cover l2l3 config negative automation cases.

Test logs are:
1. Rebuild OVS log  [RebuildOVS.txt](https://github.com/ipdk-io/ovs/files/9440806/RebuildOVS.txt)
2. Unite test in format of running test suite.   [ptf_tests_run25.log](https://github.com/ipdk-io/ovs/files/9440812/ptf_tests_run25.log)
3.  Suite test log  [ptf_tests_runAll20.log](https://github.com/ipdk-io/ovs/files/9440813/ptf_tests_runAll20.log)

