### PR TITLE
Changes to reduce build time and size

### DIFF
--- a/build-p4ovs.sh
+++ b/build-p4ovs.sh
@@ -41,9 +41,9 @@ fi
 ./boot.sh || exit 1
 if [ ! -z "$DEPS_INSTALL_PATH" ]
 then
-    ./configure --prefix=$DEPS_INSTALL_PATH --with-p4tdi=$SDE_INSTALL_PATH CFLAGS='-O0 -g' --disable-ssl --with-sai || exit 1
+    ./configure --prefix=$DEPS_INSTALL_PATH --with-p4tdi=$SDE_INSTALL_PATH CFLAGS='-O0' --disable-ssl --with-sai || exit 1
 else
-    ./configure --with-p4tdi=$SDE_INSTALL_PATH CFLAGS='-O0 -g' --with-sai || exit 1
+    ./configure --with-p4tdi=$SDE_INSTALL_PATH CFLAGS='-O0' --disable-ssl --with-sai || exit 1
 fi
 
 #Read the number of CPUs in a system and derive the NUM threads

--- a/install_dep_packages.sh
+++ b/install_dep_packages.sh
@@ -111,7 +111,7 @@ cd "$SRC_DIR"/"$MODULE"
 git checkout 503e3dec8d1fe071376befc62119a837c26612a3
 mkdir -p "$SRC_DIR"/"$MODULE"/build
 cd "$SRC_DIR"/"$MODULE"/build
-cmake $CMAKE_PREFIX -Dgflags_DIR:PATH="$INSTALL_DIR"/lib/cmake/gflags ..
+cmake $CMAKE_PREFIX -Dgflags_DIR:PATH="$INSTALL_DIR"/lib/cmake/gflags -DWITH_GTEST=OFF ..
 make "$NUM_THREADS"
 sudo make "$NUM_THREADS" install
 sudo ldconfig
@@ -184,7 +184,7 @@ cd "$SRC_DIR"/"$MODULE"
 git checkout 760304635dc74a5bf77903ad92446a6febb85acf
 mkdir -p "$SRC_DIR"/"$MODULE"/build
 cd "$SRC_DIR"/"$MODULE"/build
-cmake "$CMAKE_PREFIX" ..
+cmake "$CMAKE_PREFIX" -DJSON_BuildTests=OFF ..
 make "$NUM_THREADS"
 sudo make "$NUM_THREADS" install
 sudo ldconfig


### PR DESCRIPTION
- Because of debug option, size of image is increased. Removing build with -g option. User need to add this flag if needed for debugging.
- Disabling SSL when we build with default path as well.

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>