### PR TITLE
Update python version to 3.10

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -565,7 +565,7 @@ AC_DEFUN([OVS_CHECK_P4TDI], [
                 [libbfutils libbfsys libdriver],
                 [P4TDI_INCLUDE="$P4TDI_CFLAGS"],
                 [P4TDI_INCLUDE="-I/usr/local/include -I/usr/include"
-                 P4TDI_LIB="-lbfsys -lbfutils -ldriver -lpython3.8 -lstdc++ -lcjson"])
+                 P4TDI_LIB="-lbfsys -lbfutils -ldriver -lpython3.10 -lstdc++ -lcjson"])
         else
             PKG_CHECK_MODULES([P4TDI],
                 [libtarget_utils libtarget_sys libdriver libbf_switchd_lib libdpdk_infra],
@@ -588,9 +588,9 @@ AC_DEFUN([OVS_CHECK_P4TDI], [
     save_LIBS=$LIBS
 
     if test "$with_tofino" = yes; then
-        P4TDI_LIB="-lbfsys -lbfutils -ldriver -lpython3.8 -lstdc++ -lcjson"
+        P4TDI_LIB="-lbfsys -lbfutils -ldriver -lpython3.10 -lstdc++ -lcjson"
     else
-        P4TDI_LIB="-lbf_switchd_lib -ltarget_sys -ltarget_utils -ldriver -lpython3.8 -lstdc++ -ldpdk_infra -lcjson -ltdi -ltdi_json_parser"
+        P4TDI_LIB="-ldriver -lbf_switchd_lib -ltarget_sys -ltarget_utils -lpython3.10 -lstdc++ -ldpdk_infra -lcjson -ltdi -ltdi_json_parser"
     fi
     CFLAGS="$CFLAGS $P4TDI_INCLUDE"
     LIBS="$P4TDI_LIB $save_LIBS"


### PR DESCRIPTION
Changes to link the latest version of python.
P4 SDE uses the version 3.10 and same is used with OvS.

Signed-off-by: Venkata Suresh Kumar P <venkata.suresh.kumar.p@intel.com>