### PR TITLE
Ignore CODEOWNERS file in dist-hook-git

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,7 @@ ALL_LOCAL += dist-hook-git
 dist-hook-git: distfiles
 	@if test -e $(srcdir)/.git && (git --version) >/dev/null 2>&1; then \
 	  (cd $(srcdir) && git ls-files) | grep -v '\.gitignore$$' | \
-	    grep -v '\.gitattributes$$' | \
+	    grep -v '\.gitattributes$$' | grep -v 'CODEOWNERS' | \
 	    LC_ALL=C sort -u > all-gitfiles; \
 	  LC_ALL=C comm -1 -3 distfiles all-gitfiles > missing-distfiles; \
 	  if test -s missing-distfiles; then \


### PR DESCRIPTION
The addition of the CODEOWNERS file broke the OVS build.
```text
The following files are in git but not the distribution:
.github/CODEOWNERS
```
This PR causes the dist-hook-git check to ignore the CODEOWNERS file.

It's not a particularly elegant fix, but none of the alternatives I tried were successful.