### PR TITLE
Support linux networking version 2

### DIFF
--- a/include/openvswitch/ovs-p4rt.h
+++ b/include/openvswitch/ovs-p4rt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Intel Corporation.
+ * Copyright (c) 2022-2023 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Defines the public interface to an externally-supplied module
@@ -15,8 +15,14 @@
 extern "C" {
 #endif
 
-#define VPORT_ID_OFFSET 16
-#define MAX_P4_BRIDGE_ID 256
+/* When VSI ID is used as an action, we need add an offset of 16 and populate
+ * the action */
+#define VSI_ID_OFFSET 16
+/* As p4 program uses 8 bits for bridge ID, current limitation is we can go max
+ * of 256 bridges (0-255) */
+#define MAX_P4_BRIDGE_ID 255
+/* Source port for VxLAN should start from 2048, 0 to 2047 are reserved for
+ * VSI/phy ports */
 #define P4_VXLAN_SOURCE_PORT_OFFSET 2048
 
 /* This is a replica of port_vlan_mode in ofproto.h */
@@ -44,38 +50,38 @@ struct port_vlan_info {
 };
 
 struct tunnel_info {
-    uint32_t ifindex;
-    uint32_t port_id;
-    uint32_t src_port;
-    struct p4_ipaddr local_ip;
-    struct p4_ipaddr remote_ip;
-    uint16_t dst_port;
-    uint16_t vni;
-    struct port_vlan_info vlan_info;
-    uint8_t bridge_id;
+  uint32_t ifindex;
+  uint32_t port_id;
+  uint32_t src_port;
+  struct p4_ipaddr local_ip;
+  struct p4_ipaddr remote_ip;
+  uint16_t dst_port;
+  uint16_t vni;
+  struct port_vlan_info vlan_info;
+  uint8_t bridge_id;
 };
 
 struct src_port_info {
-    uint8_t bridge_id;
-    uint16_t vlan_id;
-    uint32_t src_port;
+  uint8_t bridge_id;
+  uint16_t vlan_id;
+  uint32_t src_port;
 };
 
 struct vlan_info {
-    uint32_t vlan_id;
+  uint32_t vlan_id;
 };
 
 struct mac_learning_info {
-    bool is_tunnel;
-    bool is_vlan;
-    uint8_t mac_addr[6];
-    uint8_t bridge_id;
-    uint32_t src_port;
-    struct port_vlan_info vlan_info;
-    union {
-        struct tunnel_info tnl_info;
-        struct vlan_info vln_info;
-    };
+  bool is_tunnel;
+  bool is_vlan;
+  uint8_t mac_addr[6];
+  uint8_t bridge_id;
+  uint32_t src_port;
+  struct port_vlan_info vlan_info;
+  union {
+    struct tunnel_info tnl_info;
+    struct vlan_info vln_info;
+  };
 };
 
 // Function declarations
@@ -87,16 +93,14 @@ extern void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
                                           bool insert_entry);
 extern void ConfigSrcPortTableEntry(struct src_port_info vsi_sp,
                                     bool insert_entry);
-extern void ConfigVlanTableEntry(uint16_t vlan_id,
-                                 bool insert_entry);
+extern void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry);
 extern void ConfigIpTunnelTermTableEntry(struct tunnel_info tunnel_info,
                                          bool insert_entry);
 extern void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
                                         bool insert_entry);
 
 #ifdef __cplusplus
-} // extern "C"
+}  // extern "C"
 #endif
 
-#endif // OPENVSWITCH_OVS_P4RT_H
-
+#endif  // OPENVSWITCH_OVS_P4RT_H

--- a/include/openvswitch/ovs-p4rt.h
+++ b/include/openvswitch/ovs-p4rt.h
@@ -15,6 +15,20 @@
 extern "C" {
 #endif
 
+#define VPORT_ID_OFFSET 16
+#define MAX_P4_BRIDGE_ID 256
+#define P4_VXLAN_SOURCE_PORT_OFFSET 2048
+
+/* This is a replica of port_vlan_mode in ofproto.h */
+enum p4_vlan_mode {
+  P4_PORT_VLAN_ACCESS,
+  P4_PORT_VLAN_TRUNK,
+  P4_PORT_VLAN_NATIVE_TAGGED,
+  P4_PORT_VLAN_NATIVE_UNTAGGED,
+  P4_PORT_VLAN_DOT1Q_TUNNEL,
+  P4_PORT_VLAN_UNSUPPORTED
+};
+
 struct p4_ipaddr {
   uint8_t family;
   uint8_t prefix_len;
@@ -24,13 +38,27 @@ struct p4_ipaddr {
   } ip;
 };
 
+struct port_vlan_info {
+  enum p4_vlan_mode port_vlan_mode;
+  int port_vlan;
+};
+
 struct tunnel_info {
     uint32_t ifindex;
     uint32_t port_id;
+    uint32_t src_port;
     struct p4_ipaddr local_ip;
     struct p4_ipaddr remote_ip;
     uint16_t dst_port;
     uint16_t vni;
+    struct port_vlan_info vlan_info;
+    uint8_t bridge_id;
+};
+
+struct src_port_info {
+    uint8_t bridge_id;
+    uint16_t vlan_id;
+    uint32_t src_port;
 };
 
 struct vlan_info {
@@ -41,6 +69,9 @@ struct mac_learning_info {
     bool is_tunnel;
     bool is_vlan;
     uint8_t mac_addr[6];
+    uint8_t bridge_id;
+    uint32_t src_port;
+    struct port_vlan_info vlan_info;
     union {
         struct tunnel_info tnl_info;
         struct vlan_info vln_info;
@@ -52,6 +83,16 @@ extern void ConfigFdbTableEntry(struct mac_learning_info learn_info,
                                 bool insert_entry);
 extern void ConfigTunnelTableEntry(struct tunnel_info tunnel_info,
                                    bool insert_entry);
+extern void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
+                                          bool insert_entry);
+extern void ConfigSrcPortTableEntry(struct src_port_info vsi_sp,
+                                    bool insert_entry);
+extern void ConfigVlanTableEntry(uint16_t vlan_id,
+                                 bool insert_entry);
+extern void ConfigIpTunnelTermTableEntry(struct tunnel_info tunnel_info,
+                                         bool insert_entry);
+extern void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
+                                        bool insert_entry);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -620,6 +620,7 @@ mac_learning_expire(struct mac_learning *ml, struct mac_entry *e)
     memset(&fdb_info, 0, sizeof(struct mac_learning_info));
     memcpy(fdb_info.mac_addr, e->mac.ea, sizeof(fdb_info.mac_addr));
     fdb_info.is_vlan = true;
+    fdb_info.bridge_id = ml->p4_bridge_id;
     ConfigFdbTableEntry(fdb_info, false);
 #endif
     free(e);

--- a/lib/mac-learning.h
+++ b/lib/mac-learning.h
@@ -190,8 +190,9 @@ struct mac_learning {
     struct hmap ports_by_ptr;   /* struct mac_learning_port hmap_nodes. */
     struct heap ports_by_usage; /* struct mac_learning_port heap_nodes. */
 
-    /* P4 specific bridge ID */
-    uint8_t p4_bridge_id;
+#if defined(P4OVS)
+    uint8_t p4_bridge_id;       /* P4 specific bridge ID */
+#endif
 };
 
 int mac_entry_age(const struct mac_learning *ml, const struct mac_entry *e)

--- a/lib/mac-learning.h
+++ b/lib/mac-learning.h
@@ -189,6 +189,9 @@ struct mac_learning {
      * ports_by_ptr is a hash table indexed by the client-provided pointer. */
     struct hmap ports_by_ptr;   /* struct mac_learning_port hmap_nodes. */
     struct heap ports_by_usage; /* struct mac_learning_port heap_nodes. */
+
+    /* P4 specific bridge ID */
+    uint8_t p4_bridge_id;
 };
 
 int mac_entry_age(const struct mac_learning *ml, const struct mac_entry *e)

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -74,7 +74,6 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include "openvswitch/ovs-p4rt.h"
-struct ofbundle;
 #endif //P4OVS
 
 COVERAGE_DEFINE(xlate_actions);
@@ -164,7 +163,7 @@ struct xbundle {
     bool floodable;                /* No port has OFPUTIL_PC_NO_FLOOD set? */
     bool protected;                /* Protected port mode */
 #if defined(P4OVS)
-    uint8_t p4_bridge_id;
+    uint8_t p4_bridge_id;          /* P4 specific bridge ID for this xbundle */
 #endif
 };
 
@@ -3064,23 +3063,30 @@ get_p4_vlan_mode(enum port_vlan_mode vlan_mode) {
         return P4_PORT_VLAN_NATIVE_TAGGED;
     else if (vlan_mode == PORT_VLAN_NATIVE_UNTAGGED)
         return P4_PORT_VLAN_NATIVE_UNTAGGED;
-    else if (vlan_mode == PORT_VLAN_DOT1Q_TUNNEL)
-        return P4_PORT_VLAN_DOT1Q_TUNNEL;
     else
-        return -1;
+        return P4_PORT_VLAN_UNSUPPORTED;
 }
 
 static int32_t
 get_fdb_data(struct xport *port, struct eth_addr mac_addr,
              struct mac_learning_info *fdb_info)
 {
+    enum p4_vlan_mode v_mode;
     if (!port || !port->netdev || !port->xbundle) {
         return -1;
     }
 
     memcpy(fdb_info->mac_addr, mac_addr.ea, sizeof(fdb_info->mac_addr));
     fdb_info->bridge_id = port->xbundle->p4_bridge_id;
-    fdb_info->vlan_info.port_vlan_mode = get_p4_vlan_mode(port->xbundle->vlan_mode);
+
+    v_mode = get_p4_vlan_mode(port->xbundle->vlan_mode);
+
+    if (v_mode == P4_PORT_VLAN_UNSUPPORTED) {
+        VLOG_DBG("Unsupported VLAN mode");
+        return -1;
+    }
+
+    fdb_info->vlan_info.port_vlan_mode = v_mode;
     fdb_info->vlan_info.port_vlan = port->xbundle->vlan;
 
     if (port->is_tunnel) {
@@ -3121,6 +3127,23 @@ get_fdb_data(struct xport *port, struct eth_addr mac_addr,
     } else {
         const char *port_name = port->xbundle->name;
         if (strncmp(port_name, "vlan", strlen("vlan"))) {
+            struct eth_addr smac;
+            int err = netdev_get_etheraddr(port->netdev, &smac);
+            if (err) {
+                VLOG_DBG("Cannot retrieve Source MAC address for port: %s",
+                          port_name);
+                return -1;
+            }
+            if (!memcmp(smac.ea, mac_addr.ea, sizeof(smac))) {
+                VLOG_DBG("Ignore self MAC learn use case for port: %s",
+                          port_name);
+                return -1;
+
+            }
+            /* this SRC port MAC is needed to configure FDB entry
+             * for its corresponding HOST port or Phy port.
+             */
+            fdb_info->src_port = smac.ea[1] + VSI_ID_OFFSET;
             VLOG_DBG("Continue, this is latest LNW");
         } else {
            fdb_info->is_vlan = true;
@@ -3231,11 +3254,11 @@ xlate_normal(struct xlate_ctx *ctx)
         ConfigFdbTableEntry(fdb_info, true);
         ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
     } else {
-        VLOG_ERR("Error retrieving FDB information, skipping programming "
+        VLOG_DBG("Error retrieving FDB information, skipping programming "
                  "P4 entry");
     }
 #endif
-    
+
     if (ctx->xin->xcache && in_xbundle != &ofpp_none_bundle) {
         struct xc_entry *entry;
 
@@ -8511,14 +8534,10 @@ xlate_add_static_mac_entry(const struct ofproto_dpif *ofproto,
     memset(&fdb_info, 0, sizeof(fdb_info));
 
     if (!get_fdb_data(ovs_port, dl_src, &fdb_info)) {
-        struct eth_addr smac;
-        int err = netdev_get_etheraddr(ovs_port->netdev, &smac);
-        if (!err) {
-            ConfigFdbTableEntry(fdb_info, true);
-        }
+        ConfigFdbTableEntry(fdb_info, true);
         ofproto->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
     } else {
-        VLOG_ERR("Error retrieving FDB information, skipping programming "
+        VLOG_DBG("Error retrieving FDB information, skipping programming "
                  "P4 entry");
     }
 #endif

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -74,6 +74,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include "openvswitch/ovs-p4rt.h"
+struct ofbundle;
 #endif //P4OVS
 
 COVERAGE_DEFINE(xlate_actions);
@@ -162,6 +163,9 @@ struct xbundle {
                                    /* Use 802.1p tag for frames in VLAN 0? */
     bool floodable;                /* No port has OFPUTIL_PC_NO_FLOOD set? */
     bool protected;                /* Protected port mode */
+#if defined(P4OVS)
+    uint8_t p4_bridge_id;
+#endif
 };
 
 struct xport {
@@ -617,6 +621,15 @@ static void xlate_xbridge_set(struct xbridge *, struct dpif *,
                               bool forward_bpdu, bool has_in_band,
                               const struct dpif_backer_support *,
                               const struct xbridge_addr *);
+#if defined(P4OVS)
+static void xlate_xbundle_set(struct xbundle *xbundle,
+                              enum port_vlan_mode vlan_mode,
+                              uint16_t qinq_ethtype, int vlan,
+                              unsigned long *trunks, unsigned long *cvlans,
+                              enum port_priority_tags_mode,
+                              const struct bond *bond, const struct lacp *lacp,
+                              bool floodable, bool protected, uint8_t p4_bridge_id);
+#elif
 static void xlate_xbundle_set(struct xbundle *xbundle,
                               enum port_vlan_mode vlan_mode,
                               uint16_t qinq_ethtype, int vlan,
@@ -624,6 +637,7 @@ static void xlate_xbundle_set(struct xbundle *xbundle,
                               enum port_priority_tags_mode,
                               const struct bond *bond, const struct lacp *lacp,
                               bool floodable, bool protected);
+#endif
 static void xlate_xport_set(struct xport *xport, odp_port_t odp_port,
                             const struct netdev *netdev, const struct cfm *cfm,
                             const struct bfd *bfd, const struct lldp *lldp,
@@ -1023,6 +1037,15 @@ xlate_xbridge_set(struct xbridge *xbridge,
     xbridge->support = *support;
 }
 
+#if defined(P4OVS)
+static void
+xlate_xbundle_set(struct xbundle *xbundle,
+                  enum port_vlan_mode vlan_mode, uint16_t qinq_ethtype,
+                  int vlan, unsigned long *trunks, unsigned long *cvlans,
+                  enum port_priority_tags_mode use_priority_tags,
+                  const struct bond *bond, const struct lacp *lacp,
+                  bool floodable, bool protected, uint8_t p4_bridge_id)
+#elif
 static void
 xlate_xbundle_set(struct xbundle *xbundle,
                   enum port_vlan_mode vlan_mode, uint16_t qinq_ethtype,
@@ -1030,6 +1053,7 @@ xlate_xbundle_set(struct xbundle *xbundle,
                   enum port_priority_tags_mode use_priority_tags,
                   const struct bond *bond, const struct lacp *lacp,
                   bool floodable, bool protected)
+#endif
 {
     ovs_assert(xbundle->xbridge);
 
@@ -1041,6 +1065,10 @@ xlate_xbundle_set(struct xbundle *xbundle,
     xbundle->use_priority_tags = use_priority_tags;
     xbundle->floodable = floodable;
     xbundle->protected = protected;
+
+#if defined(P4OVS)
+    xbundle->p4_bridge_id = p4_bridge_id;
+#endif
 
     if (xbundle->bond != bond) {
         bond_unref(xbundle->bond);
@@ -1133,10 +1161,18 @@ xlate_xbundle_copy(struct xbridge *xbridge, struct xbundle *xbundle)
     new_xbundle->name = xstrdup(xbundle->name);
     xlate_xbundle_init(new_xcfg, new_xbundle);
 
+#if defined(P4OVS)
+    xlate_xbundle_set(new_xbundle, xbundle->vlan_mode, xbundle->qinq_ethtype,
+                      xbundle->vlan, xbundle->trunks, xbundle->cvlans,
+                      xbundle->use_priority_tags, xbundle->bond, xbundle->lacp,
+                      xbundle->floodable, xbundle->protected,
+                      xbundle->p4_bridge_id);
+#elif
     xlate_xbundle_set(new_xbundle, xbundle->vlan_mode, xbundle->qinq_ethtype,
                       xbundle->vlan, xbundle->trunks, xbundle->cvlans,
                       xbundle->use_priority_tags, xbundle->bond, xbundle->lacp,
                       xbundle->floodable, xbundle->protected);
+#endif
     LIST_FOR_EACH (xport, bundle_node, &xbundle->xports) {
         xlate_xport_copy(xbridge, new_xbundle, xport);
     }
@@ -1343,6 +1379,16 @@ xlate_remove_ofproto(struct ofproto_dpif *ofproto)
     xlate_xbridge_remove(new_xcfg, xbridge);
 }
 
+#if defined(P4OVS)
+void
+xlate_bundle_set(struct ofproto_dpif *ofproto, struct ofbundle *ofbundle,
+                 const char *name, enum port_vlan_mode vlan_mode,
+                 uint16_t qinq_ethtype, int vlan,
+                 unsigned long *trunks, unsigned long *cvlans,
+                 enum port_priority_tags_mode use_priority_tags,
+                 const struct bond *bond, const struct lacp *lacp,
+                 bool floodable, bool protected, uint8_t p4_bridge_id)
+#elif
 void
 xlate_bundle_set(struct ofproto_dpif *ofproto, struct ofbundle *ofbundle,
                  const char *name, enum port_vlan_mode vlan_mode,
@@ -1351,6 +1397,7 @@ xlate_bundle_set(struct ofproto_dpif *ofproto, struct ofbundle *ofbundle,
                  enum port_priority_tags_mode use_priority_tags,
                  const struct bond *bond, const struct lacp *lacp,
                  bool floodable, bool protected)
+#endif
 {
     struct xbundle *xbundle;
 
@@ -1368,8 +1415,14 @@ xlate_bundle_set(struct ofproto_dpif *ofproto, struct ofbundle *ofbundle,
     free(xbundle->name);
     xbundle->name = xstrdup(name);
 
+#if defined(P4OVS)
+    xlate_xbundle_set(xbundle, vlan_mode, qinq_ethtype, vlan, trunks, cvlans,
+                      use_priority_tags, bond, lacp, floodable, protected,
+                      p4_bridge_id);
+#elif
     xlate_xbundle_set(xbundle, vlan_mode, qinq_ethtype, vlan, trunks, cvlans,
                       use_priority_tags, bond, lacp, floodable, protected);
+#endif
 }
 
 static void
@@ -3001,6 +3054,22 @@ is_ip_local_multicast(const struct flow *flow, struct flow_wildcards *wc)
 }
 
 #if defined(P4OVS)
+static enum p4_vlan_mode
+get_p4_vlan_mode(enum port_vlan_mode vlan_mode) {
+    if (vlan_mode == PORT_VLAN_ACCESS)
+        return P4_PORT_VLAN_ACCESS;
+    else if (vlan_mode == PORT_VLAN_TRUNK)
+        return P4_PORT_VLAN_TRUNK;
+    else if (vlan_mode == PORT_VLAN_NATIVE_TAGGED)
+        return P4_PORT_VLAN_NATIVE_TAGGED;
+    else if (vlan_mode == PORT_VLAN_NATIVE_UNTAGGED)
+        return P4_PORT_VLAN_NATIVE_UNTAGGED;
+    else if (vlan_mode == PORT_VLAN_DOT1Q_TUNNEL)
+        return P4_PORT_VLAN_DOT1Q_TUNNEL;
+    else
+        return -1;
+}
+
 static int32_t
 get_fdb_data(struct xport *port, struct eth_addr mac_addr,
              struct mac_learning_info *fdb_info)
@@ -3010,8 +3079,13 @@ get_fdb_data(struct xport *port, struct eth_addr mac_addr,
     }
 
     memcpy(fdb_info->mac_addr, mac_addr.ea, sizeof(fdb_info->mac_addr));
+    fdb_info->bridge_id = port->xbundle->p4_bridge_id;
+    fdb_info->vlan_info.port_vlan_mode = get_p4_vlan_mode(port->xbundle->vlan_mode);
+    fdb_info->vlan_info.port_vlan = port->xbundle->vlan;
+
     if (port->is_tunnel) {
         fdb_info->is_tunnel = port->is_tunnel;
+
         const struct netdev_tunnel_config *underlay_tnl = NULL;
         underlay_tnl = netdev_get_tunnel_config(port->netdev);
         if (!underlay_tnl) {
@@ -3047,8 +3121,7 @@ get_fdb_data(struct xport *port, struct eth_addr mac_addr,
     } else {
         const char *port_name = port->xbundle->name;
         if (strncmp(port_name, "vlan", strlen("vlan"))) {
-            VLOG_ERR("Not a VLAN interface, port name = %s", port_name);
-            return -1;
+            VLOG_DBG("Continue, this is latest LNW");
         } else {
            fdb_info->is_vlan = true;
            int fd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -3156,6 +3229,7 @@ xlate_normal(struct xlate_ctx *ctx)
 
     if (!get_fdb_data(ovs_port, flow->dl_src, &fdb_info)) {
         ConfigFdbTableEntry(fdb_info, true);
+        ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
     } else {
         VLOG_ERR("Error retrieving FDB information, skipping programming "
                  "P4 entry");
@@ -8437,7 +8511,12 @@ xlate_add_static_mac_entry(const struct ofproto_dpif *ofproto,
     memset(&fdb_info, 0, sizeof(fdb_info));
 
     if (!get_fdb_data(ovs_port, dl_src, &fdb_info)) {
-        ConfigFdbTableEntry(fdb_info, true);
+        struct eth_addr smac;
+        int err = netdev_get_etheraddr(ovs_port->netdev, &smac);
+        if (!err) {
+            ConfigFdbTableEntry(fdb_info, true);
+        }
+        ofproto->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
     } else {
         VLOG_ERR("Error retrieving FDB information, skipping programming "
                  "P4 entry");

--- a/ofproto/ofproto-dpif-xlate.h
+++ b/ofproto/ofproto-dpif-xlate.h
@@ -182,6 +182,15 @@ void xlate_ofproto_set(struct ofproto_dpif *, const char *name, struct dpif *,
 void xlate_remove_ofproto(struct ofproto_dpif *);
 struct ofproto_dpif *xlate_ofproto_lookup(const struct uuid *uuid);
 
+#if defined(P4OVS)
+void xlate_bundle_set(struct ofproto_dpif *, struct ofbundle *,
+                      const char *name, enum port_vlan_mode,
+                      uint16_t qinq_ethtype, int vlan,
+                      unsigned long *trunks, unsigned long *cvlans,
+                      enum port_priority_tags_mode,
+                      const struct bond *, const struct lacp *,
+                      bool floodable, bool protected, uint8_t p4_bridge_id);
+#elif
 void xlate_bundle_set(struct ofproto_dpif *, struct ofbundle *,
                       const char *name, enum port_vlan_mode,
                       uint16_t qinq_ethtype, int vlan,
@@ -189,6 +198,7 @@ void xlate_bundle_set(struct ofproto_dpif *, struct ofbundle *,
                       enum port_priority_tags_mode,
                       const struct bond *, const struct lacp *,
                       bool floodable, bool protected);
+#endif
 void xlate_bundle_remove(struct ofbundle *);
 
 void xlate_ofport_set(struct ofproto_dpif *, struct ofbundle *,

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -113,7 +113,7 @@ struct ofbundle {
     /* Status. */
     bool floodable;          /* True if no port has OFPUTIL_PC_NO_FLOOD set. */
 #if defined(P4OVS)
-    uint8_t p4_bridge_id;
+    uint8_t p4_bridge_id;    /* P4 specific bridge ID for this ofbundle */
 #endif
 };
 
@@ -3335,7 +3335,9 @@ bundle_set(struct ofproto *ofproto_, void *aux,
 
         bundle->floodable = true;
         bundle->protected = false;
+#if defined(P4OVS)
         bundle->p4_bridge_id = s->p4_bridge_id;
+#endif
         mbridge_register_bundle(ofproto->mbridge, bundle);
     }
 

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -75,9 +75,6 @@
 
 #if defined(P4OVS)
 #include "openvswitch/ovs-p4rt.h"
-static int32_t
-get_tunnel_data(struct netdev *netdev,
-                struct tunnel_info *tnl_info);
 #endif
 
 VLOG_DEFINE_THIS_MODULE(ofproto_dpif);
@@ -115,6 +112,9 @@ struct ofbundle {
 
     /* Status. */
     bool floodable;          /* True if no port has OFPUTIL_PC_NO_FLOOD set. */
+#if defined(P4OVS)
+    uint8_t p4_bridge_id;
+#endif
 };
 
 static void bundle_remove(struct ofport *);
@@ -491,12 +491,22 @@ type_run(const char *type)
                               &ofproto->backer->rt_support);
 
             HMAP_FOR_EACH (bundle, hmap_node, &ofproto->bundles) {
+#if defined(P4OVS)
+                xlate_bundle_set(ofproto, bundle, bundle->name,
+                                 bundle->vlan_mode, bundle->qinq_ethtype,
+                                 bundle->vlan, bundle->trunks, bundle->cvlans,
+                                 bundle->use_priority_tags,
+                                 bundle->bond, bundle->lacp,
+                                 bundle->floodable, bundle->protected,
+                                 bundle->p4_bridge_id);
+#elif
                 xlate_bundle_set(ofproto, bundle, bundle->name,
                                  bundle->vlan_mode, bundle->qinq_ethtype,
                                  bundle->vlan, bundle->trunks, bundle->cvlans,
                                  bundle->use_priority_tags,
                                  bundle->bond, bundle->lacp,
                                  bundle->floodable, bundle->protected);
+#endif
             }
 
             HMAP_FOR_EACH (ofport, up.hmap_node, &ofproto->up.ports) {
@@ -2227,18 +2237,6 @@ port_destruct(struct ofport *port_, bool del)
     }
 
     tnl_port_del(port, port->odp_port);
-#if defined(P4OVS)
-    if (port->is_tunnel) {
-        struct tunnel_info tnl_info;
-        memset(&tnl_info, 0, sizeof(tnl_info));
-        if (!get_tunnel_data(port->up.netdev, &tnl_info)) {
-            ConfigTunnelTableEntry(tnl_info, false);
-        } else {
-            VLOG_ERR("Error retrieving tunnel information, skipping programming "
-                     "P4 entry");
-        }
-    }
-#endif  
     sset_find_and_delete(&ofproto->ports, devname);
     sset_find_and_delete(&ofproto->ghost_ports, devname);
     bundle_remove(port_);
@@ -3337,6 +3335,7 @@ bundle_set(struct ofproto *ofproto_, void *aux,
 
         bundle->floodable = true;
         bundle->protected = false;
+        bundle->p4_bridge_id = s->p4_bridge_id;
         mbridge_register_bundle(ofproto->mbridge, bundle);
     }
 
@@ -3955,47 +3954,6 @@ port_query_by_name(const struct ofproto *ofproto_, const char *devname,
     return error;
 }
 
-#if defined(P4OVS)
-static int32_t
-get_tunnel_data(struct netdev *netdev,
-                struct tunnel_info *tnl_info)
-{
-     const struct netdev_tunnel_config *underlay_tnl = NULL;
-     underlay_tnl = netdev_get_tunnel_config(netdev);
-     if (!underlay_tnl) {
-         VLOG_ERR("Error retrieving netdev tunnel config");
-         return -1;
-     }
-     int underlay_ifindex = netdev_get_ifindex(netdev);
-     if (underlay_ifindex < 0) {
-         VLOG_ERR("Invalid tunnel ifindex");
-         return -1;
-     }
-     tnl_info->ifindex = (uint32_t)underlay_ifindex;
-     if (underlay_tnl->ipv6_src.__in6_u.__u6_addr32[0]) {
-         /* IPv6 tunnel configuration */
-         tnl_info->local_ip.family = AF_INET6;
-         tnl_info->local_ip.ip.v6addr = (struct in6_addr) underlay_tnl->ipv6_src;
-
-         tnl_info->remote_ip.family = AF_INET6;
-         tnl_info->remote_ip.ip.v6addr = (struct in6_addr) underlay_tnl->ipv6_dst;
-
-     } else {
-         /* IPv4 tunnel configuration */
-         tnl_info->local_ip.family = AF_INET;
-         tnl_info->local_ip.ip.v4addr.s_addr = underlay_tnl->ipv6_src.__in6_u.__u6_addr32[3];
-
-         tnl_info->remote_ip.family = AF_INET;
-         tnl_info->remote_ip.ip.v4addr.s_addr = underlay_tnl->ipv6_dst.__in6_u.__u6_addr32[3];
-     }
-
-     tnl_info->dst_port = underlay_tnl->dst_port;
-     tnl_info->vni = underlay_tnl->vni;
-
-    return 0;
-}
-#endif
-
 static int
 port_add(struct ofproto *ofproto_, struct netdev *netdev)
 {
@@ -4034,18 +3992,6 @@ port_add(struct ofproto *ofproto_, struct netdev *netdev)
         sset_add(&ofproto->ports, devname);
     }
 
-#if defined(P4OVS)
-    if (netdev_get_tunnel_config(netdev)) {
-        struct tunnel_info tnl_info;
-        memset(&tnl_info, 0, sizeof(tnl_info));
-        if (!get_tunnel_data(netdev, &tnl_info)) {
-            ConfigTunnelTableEntry(tnl_info, true);
-        } else {
-            VLOG_ERR("Error retrieving tunnel information, skipping programming "
-                     "P4 entry");
-        }
-    }
-#endif
     return 0;
 }
 

--- a/ofproto/ofproto.h
+++ b/ofproto/ofproto.h
@@ -459,6 +459,9 @@ struct ofproto_bundle_settings {
     struct lacp_member_settings *lacp_members; /* Array of n_members elements. */
 
     bool protected;             /* Protected port mode */
+#if defined(P4OVS)
+    uint8_t p4_bridge_id;       /* Unique bridge ID used by P4 tables */
+#endif
 };
 
 int ofproto_bundle_register(struct ofproto *, void *aux,

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -2183,7 +2183,7 @@ GetSrcPortVsiId(char *mac_addr) {
         VLOG_ERR("Cannot convert MAC address: %s to binary data", mac_addr);
         return 0;
     }
-    return ea->ether_addr_octet[1] + VPORT_ID_OFFSET;
+    return ea->ether_addr_octet[1] + VSI_ID_OFFSET;
 }
 
 static void
@@ -2226,8 +2226,11 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                      "skipping programming P4 entry");
         }
 
-        if (port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED ||
-            port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
+        if (port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED) {
+            /* only for native VLAN ports we need to add VLAN when
+             * configuring SRC port table. As this port only accepts
+             * TAGGED packets
+             */
             struct src_port_info tnl_src_port_info = {br->p4_bridge_id,
                                                       port->p4_vlan_id,
                                                       port->p4_src_port};
@@ -2251,8 +2254,11 @@ ConfigureP4Target(struct bridge *br, struct port *port,
         }
 
         if (port->p4_src_port &&
-            (port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED ||
-            port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED)) {
+            (port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED)) {
+            /* only for native VLAN ports we need to add VLAN when
+             * configuring SRC port table. As this port only accepts
+             * TAGGED packets
+             */
             struct src_port_info vsi_src_port_info = {br->p4_bridge_id,
                                                       port->p4_vlan_id,
                                                       port->p4_src_port};

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -72,6 +72,19 @@
 #include "lib/vswitch-idl.h"
 #include "vlan-bitmap.h"
 
+#if defined(P4OVS)
+#include "openvswitch/ovs-p4rt.h"
+#include <netinet/ether.h>
+
+static int32_t
+get_tunnel_data(struct netdev *netdev,
+                struct tunnel_info *tnl_info);
+
+uint8_t last_p4_bridge_id_used = 0;
+uint32_t unique_tunnel_src_port = P4_VXLAN_SOURCE_PORT_OFFSET;
+
+#endif
+
 VLOG_DEFINE_THIS_MODULE(bridge);
 
 COVERAGE_DEFINE(bridge_reconfigure);
@@ -108,6 +121,13 @@ struct port {
     struct bridge *bridge;
     char *name;
 
+#if defined(P4OVS)
+    uint16_t p4_src_port;
+    bool is_src_port_configured;
+    uint16_t p4_vlan_id;
+    enum p4_vlan_mode p4_vlan_mode;
+#endif
+
     const struct ovsrec_port *cfg;
 
     /* An ordinary bridge port has 1 interface.
@@ -119,6 +139,9 @@ struct bridge {
     struct hmap_node node;      /* In 'all_bridges'. */
     char *name;                 /* User-specified arbitrary name. */
     char *type;                 /* Datapath type. */
+#if defined(P4OVS)
+    uint8_t p4_bridge_id;       /* Unique bridge ID used by P4 tables */
+#endif
     struct eth_addr ea;         /* Bridge Ethernet Address. */
     struct eth_addr default_ea; /* Default MAC. */
     const struct ovsrec_bridge *cfg;
@@ -259,6 +282,7 @@ static uint64_t last_ifaces_changed;
 #define BRIDGE_CONTROLLER_PACKET_QUEUE_DEFAULT_SIZE 100
 #define BRIDGE_CONTROLLER_PACKET_QUEUE_MIN_SIZE 1
 #define BRIDGE_CONTROLLER_PACKET_QUEUE_MAX_SIZE 512
+
 
 static void add_del_bridges(const struct ovsrec_open_vswitch *);
 static void bridge_run__(void);
@@ -1293,6 +1317,10 @@ port_configure(struct port *port)
     /* Protected port mode */
     s.protected = cfg->protected_;
 
+#if defined(P4OVS)
+    s.p4_bridge_id = port->bridge->p4_bridge_id;
+#endif
+
     /* Register. */
     ofproto_bundle_register(port->bridge->ofproto, port, &s);
 
@@ -2084,6 +2112,171 @@ error:
     return error;
 }
 
+#if defined(P4OVS)
+static int32_t
+get_tunnel_data(struct netdev *netdev,
+                struct tunnel_info *tnl_info)
+{
+     const struct netdev_tunnel_config *underlay_tnl = NULL;
+     underlay_tnl = netdev_get_tunnel_config(netdev);
+     if (!underlay_tnl) {
+         VLOG_ERR("Error retrieving netdev tunnel config");
+         return -1;
+     }
+     int underlay_ifindex = netdev_get_ifindex(netdev);
+     if (underlay_ifindex < 0) {
+         VLOG_ERR("Invalid tunnel ifindex");
+         return -1;
+     }
+     tnl_info->ifindex = (uint32_t)underlay_ifindex;
+     if (underlay_tnl->ipv6_src.__in6_u.__u6_addr32[0]) {
+         /* IPv6 tunnel configuration */
+         tnl_info->local_ip.family = AF_INET6;
+         tnl_info->local_ip.ip.v6addr = (struct in6_addr) underlay_tnl->ipv6_src;
+
+         tnl_info->remote_ip.family = AF_INET6;
+         tnl_info->remote_ip.ip.v6addr = (struct in6_addr) underlay_tnl->ipv6_dst;
+
+     } else {
+         /* IPv4 tunnel configuration */
+         tnl_info->local_ip.family = AF_INET;
+         tnl_info->local_ip.ip.v4addr.s_addr = underlay_tnl->ipv6_src.__in6_u.__u6_addr32[3];
+
+         tnl_info->remote_ip.family = AF_INET;
+         tnl_info->remote_ip.ip.v4addr.s_addr = underlay_tnl->ipv6_dst.__in6_u.__u6_addr32[3];
+     }
+
+     tnl_info->dst_port = underlay_tnl->dst_port;
+     tnl_info->vni = underlay_tnl->vni;
+
+    return 0;
+}
+
+static bool
+get_p4_vlan_info(const struct ovsrec_port *cfg,
+                 struct port *port) {
+    if (cfg && cfg->vlan_mode) {
+        if (!strcmp(cfg->vlan_mode, "native-tagged")) {
+            port->p4_vlan_mode = P4_PORT_VLAN_NATIVE_TAGGED;
+            port->p4_vlan_id = *cfg->tag;
+        } else if (!strcmp(cfg->vlan_mode, "native-untagged")) {
+            port->p4_vlan_mode = P4_PORT_VLAN_NATIVE_UNTAGGED;
+            port->p4_vlan_id = *cfg->tag;
+        } else {
+            /* Do Nothing, no support yet */
+            port->p4_vlan_mode = P4_PORT_VLAN_UNSUPPORTED;
+            port->p4_vlan_id = 0;
+            VLOG_DBG("Unsupported VLAN mode for the P4 target");
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static uint32_t
+GetSrcPortVsiId(char *mac_addr) {
+    struct ether_addr *ea;
+
+    ea = ether_aton((const char *)mac_addr);
+    if (!ea) {
+        VLOG_ERR("Cannot convert MAC address: %s to binary data", mac_addr);
+        return 0;
+    }
+    return ea->ether_addr_octet[1] + VPORT_ID_OFFSET;
+}
+
+static void
+ConfigureP4Target(struct bridge *br, struct port *port,
+                  struct iface *iface, bool insert_entry) {
+    if (!iface->cfg || !iface->cfg->type) {
+        VLOG_DBG("Invalid interface data to configure P4 Target");
+        return;
+    }
+
+    if (!strcmp(iface->cfg->type, "internal")) {
+        VLOG_DBG("Ignore OVS specific internal interfaces");
+        return;
+    }
+
+    /* Update parent bridge's unique ID in port structure */
+    if (!strcmp(iface->cfg->type, "vxlan") ||
+        netdev_get_tunnel_config(iface->netdev)) {
+        /* Handling VxLAN source port addition */
+        struct tunnel_info tnl_info;
+
+        memset(&tnl_info, 0, sizeof(tnl_info));
+
+        if (insert_entry) {
+            get_p4_vlan_info(port->cfg, port);
+            port->p4_src_port = unique_tunnel_src_port++;
+        }
+
+        if (!get_tunnel_data(iface->netdev, &tnl_info)) {
+            tnl_info.vlan_info.port_vlan = port->p4_vlan_id;
+            tnl_info.vlan_info.port_vlan_mode = port->p4_vlan_mode;
+            tnl_info.bridge_id = br->p4_bridge_id;
+            tnl_info.src_port = port->p4_src_port;
+
+            ConfigTunnelTableEntry(tnl_info, insert_entry);
+            ConfigIpTunnelTermTableEntry(tnl_info, insert_entry);
+            ConfigRxTunnelSrcTableEntry(tnl_info, insert_entry);
+        } else {
+            VLOG_ERR("Error retrieving tunnel information, "
+                     "skipping programming P4 entry");
+        }
+
+        if (port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED ||
+            port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED) {
+            struct src_port_info tnl_src_port_info = {br->p4_bridge_id,
+                                                      port->p4_vlan_id,
+                                                      port->p4_src_port};
+            /* When VLAN tag is configured */
+            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry);
+            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry);
+        } else {
+            /* Wild card VLAN 0 */
+            struct src_port_info tnl_src_port_info = {br->p4_bridge_id,
+                                                      0,
+                                                      port->p4_src_port};
+
+            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry);
+        }
+        port->is_src_port_configured = insert_entry;
+    } else if (!insert_entry || iface->cfg->mac_in_use) {
+        /* Handling VSI source port addition */
+        if (insert_entry) {
+            get_p4_vlan_info(port->cfg, port);
+            port->p4_src_port = GetSrcPortVsiId(iface->cfg->mac_in_use);
+        }
+
+        if (port->p4_src_port &&
+            (port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_TAGGED ||
+            port->p4_vlan_mode == P4_PORT_VLAN_NATIVE_UNTAGGED)) {
+            struct src_port_info vsi_src_port_info = {br->p4_bridge_id,
+                                                      port->p4_vlan_id,
+                                                      port->p4_src_port};
+
+            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry);
+            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry);
+        } else if (port->p4_vlan_mode == P4_PORT_VLAN_UNSUPPORTED) {
+            /* Do nothing, unsupported vlan mode */
+        } else if (port->p4_src_port) {
+            struct src_port_info vsi_src_port_info = {br->p4_bridge_id,
+                                                      0,
+                                                      port->p4_src_port};
+
+            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry);
+        } else {
+            VLOG_DBG("Invalid P4 use case for source port to "
+                     "bridge mapping");
+        }
+        port->is_src_port_configured = insert_entry;
+    }
+    return;
+}
+#endif
+
 /* Creates a new iface on 'br' based on 'if_cfg'.  The new iface has OpenFlow
  * port number 'ofp_port'.  If ofp_port is OFPP_NONE, an OpenFlow port is
  * automatically allocated for the iface.  Takes ownership of and
@@ -2133,6 +2326,12 @@ iface_create(struct bridge *br, const struct ovsrec_interface *iface_cfg,
     /* Populate initial status in database. */
     iface_refresh_stats(iface);
     iface_refresh_netdev_status(iface);
+
+#if defined(P4OVS)
+    if (!port->is_src_port_configured) {
+        ConfigureP4Target(br, port, iface, true);
+    }
+#endif
 
     /* Add bond fake iface if necessary. */
     if (port_is_bond_fake_iface(port)) {
@@ -3547,6 +3746,18 @@ bridge_create(const struct ovsrec_bridge *br_cfg)
 
     hmap_init(&br->mappings);
     hmap_insert(&all_bridges, &br->node, hash_string(br->name, 0));
+
+#if defined(P4OVS)
+    /* TODO: Implement a better logic for unique bridge ID of type uint8. */
+    if (last_p4_bridge_id_used <= MAX_P4_BRIDGE_ID) {
+        br->p4_bridge_id = last_p4_bridge_id_used++;
+        VLOG_DBG("Assigned unique P4 bridge ID of: %d, for bridge: %s",
+                    br->p4_bridge_id, br->name);
+    } else {
+        VLOG_WARN("Unable to assign unique P4 bridge ID for bridge: %s, reached"
+                  " max P4 bridge ID limit of %d", br->name, MAX_P4_BRIDGE_ID);
+    }
+#endif
 }
 
 static void
@@ -4627,6 +4838,12 @@ iface_destroy__(struct iface *iface)
         VLOG_INFO("bridge %s: deleted interface %s on port %d",
                   br->name, iface->name, iface->ofp_port);
 
+#if defined(P4OVS)
+        if (port->is_src_port_configured) {
+            ConfigureP4Target(br, port, iface, false);
+        }
+#endif
+
         if (br->ofproto && iface->ofp_port != OFPP_NONE) {
             ofproto_port_unregister(br->ofproto, iface->ofp_port);
         }
@@ -5204,3 +5421,5 @@ discover_types(const struct ovsrec_open_vswitch *cfg)
     free(iface_types);
     sset_destroy(&types);
 }
+
+


### PR DESCRIPTION
This PR includes
- Basic logic to include a unique bridge ID for each bridge creation.
- Basic logic to include a unique SRC port ID for each vxlan tunnel creation.
- Additional intelligence to read each port (including tunnel port) configuration and extract vlan id, vlan mode.
- Configure other new P4 tables for 
vxlan_encap (V4 and V6)
vxlan_encap_pop_vlan (V4 and V6)
vxlan_decap (V4 and V6)
vxlan_decap_push_vlan (V4 and V6)
tunnel_term (V4 and V6)
rx_tunnel (V4 and V6)
vlan_push
vlan_pop
tunnel_src_port
vsi_src_port
- Delete P4 tables when port is deleted (including vxlan) or bridge table.