### PR TITLE
Runtime option to disable OvS offload to P4 target

### DIFF
--- a/include/openvswitch/automake.mk
+++ b/include/openvswitch/automake.mk
@@ -53,7 +53,8 @@ openvswitchinclude_HEADERS = \
 
 if P4OVS
 openvswitchinclude_HEADERS += \
-	include/openvswitch/ovs-p4rt.h
+	include/openvswitch/ovs-p4rt.h \
+	include/openvswitch/p4ovs.h
 endif
 
 if HAVE_CXX

--- a/include/openvswitch/ovs-p4rt.h
+++ b/include/openvswitch/ovs-p4rt.h
@@ -15,6 +15,15 @@
 extern "C" {
 #endif
 
+/* Control OVS offload with an environment variable during runtime.
+ * If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else
+ * if OVS_P4_OFFLOAD is not set or OVS_P4_OFFLOAD is any value other
+ * than false, then by default enable OVS offload.
+ */
+#define ENABLE_OVS_P4_OFFLOAD                                                     \
+  (getenv("OVS_P4_OFFLOAD") && !strcmp(getenv("OVS_P4_OFFLOAD"), "false")) ? 0 \
+                                                                           : 1
+
 /* When VSI ID is used as an action, we need add an offset of 16 and populate
  * the action */
 #define VSI_ID_OFFSET 16

--- a/include/openvswitch/ovs-p4rt.h
+++ b/include/openvswitch/ovs-p4rt.h
@@ -15,15 +15,6 @@
 extern "C" {
 #endif
 
-/* Control OVS offload with an environment variable during runtime.
- * If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else
- * if OVS_P4_OFFLOAD is not set or OVS_P4_OFFLOAD is any value other
- * than false, then by default enable OVS offload.
- */
-#define ENABLE_OVS_P4_OFFLOAD                                                     \
-  (getenv("OVS_P4_OFFLOAD") && !strcmp(getenv("OVS_P4_OFFLOAD"), "false")) ? 0 \
-                                                                           : 1
-
 /* When VSI ID is used as an action, we need add an offset of 16 and populate
  * the action */
 #define VSI_ID_OFFSET 16

--- a/include/openvswitch/p4ovs.h
+++ b/include/openvswitch/p4ovs.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Defines the P4 OvS specific definitions. These need be used under
+ * if defined(P4OVS) scope only.
+ */
+
+#ifndef OPENVSWITCH_P4OVS_H
+#define OPENVSWITCH_P4OVS_H
+
+#include <stdint.h>
+#include "openvswitch/thread.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern struct ovs_mutex p4ovs_fdb_entry_lock;
+
+/* Control OvS offload with an environment variable during runtime.
+ * If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else
+ * if OVS_P4_OFFLOAD is not set or OVS_P4_OFFLOAD is any value other
+ * than false, then by default enable OVS offload.
+ */
+static inline bool ovs_p4_offload_enabled(void) {
+    const char* offload = getenv("OVS_P4_OFFLOAD");
+    return (offload == NULL) || strcmp(offload, "false") != 0;
+}
+
+/* OvS creates multiple handler and revalidator threads based on the number of
+ * CPU cores. These threading mechanism also associated with bridges that
+ * are created in OvS. During multiple bridge scenarios, we are seeing
+ * issues when a mutiple MAC's are learnt on different bridges at the same time.
+ * Creating a mutex and with this we are controlling p4runtime calls for each
+ * MAC learn.
+ */
+static inline void p4ovs_lock_init(const struct ovs_mutex *p4ovs_lock) {
+    return ovs_mutex_init(p4ovs_lock);
+}
+
+static inline void p4ovs_lock_destroy(const struct ovs_mutex *p4ovs_lock) {
+    return ovs_mutex_destroy(p4ovs_lock);
+}
+
+static inline void p4ovs_lock(const struct ovs_mutex *p4ovs_lock) {
+    return ovs_mutex_lock(p4ovs_lock);
+}
+
+static inline void p4ovs_unlock(const struct ovs_mutex *p4ovs_lock) {
+    return ovs_mutex_unlock(p4ovs_lock) OVS_RELEASES(p4ovs_lock);
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // OPENVSWITCH_P4OVS_H

--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -32,6 +32,7 @@
 
 #if defined(P4OVS)
 #include "openvswitch/ovs-p4rt.h"
+#include "openvswitch/p4ovs.h"
 #endif
 
 COVERAGE_DEFINE(mac_learning_learned);
@@ -616,9 +617,9 @@ mac_learning_expire(struct mac_learning *ml, struct mac_entry *e)
     hmap_remove(&ml->table, &e->hmap_node);
     ovs_list_remove(&e->lru_node);
 #if defined(P4OVS)
-    if (ENABLE_OVS_P4_OFFLOAD) {
+    if (ovs_p4_offload_enabled()) {
         struct mac_learning_info fdb_info;
-        memset(&fdb_info, 0, sizeof(struct mac_learning_info));
+        memset(&fdb_info, 0, sizeof(fdb_info));
         memcpy(fdb_info.mac_addr, e->mac.ea, sizeof(fdb_info.mac_addr));
         fdb_info.is_vlan = true;
         fdb_info.bridge_id = ml->p4_bridge_id;

--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -616,12 +616,14 @@ mac_learning_expire(struct mac_learning *ml, struct mac_entry *e)
     hmap_remove(&ml->table, &e->hmap_node);
     ovs_list_remove(&e->lru_node);
 #if defined(P4OVS)
-    struct mac_learning_info fdb_info;
-    memset(&fdb_info, 0, sizeof(struct mac_learning_info));
-    memcpy(fdb_info.mac_addr, e->mac.ea, sizeof(fdb_info.mac_addr));
-    fdb_info.is_vlan = true;
-    fdb_info.bridge_id = ml->p4_bridge_id;
-    ConfigFdbTableEntry(fdb_info, false);
+    if (ENABLE_OVS_P4_OFFLOAD) {
+        struct mac_learning_info fdb_info;
+        memset(&fdb_info, 0, sizeof(struct mac_learning_info));
+        memcpy(fdb_info.mac_addr, e->mac.ea, sizeof(fdb_info.mac_addr));
+        fdb_info.is_vlan = true;
+        fdb_info.bridge_id = ml->p4_bridge_id;
+        ConfigFdbTableEntry(fdb_info, false);
+    }
 #endif
     free(e);
 }

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -74,6 +74,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include "openvswitch/ovs-p4rt.h"
+#include "openvswitch/p4ovs.h"
 #endif //P4OVS
 
 COVERAGE_DEFINE(xlate_actions);
@@ -3244,12 +3245,13 @@ xlate_normal(struct xlate_ctx *ctx)
     }
 
 #if defined(P4OVS)
+    p4ovs_lock(&p4ovs_fdb_entry_lock);
     /* Dynamic MAC is learnt, program P4 forwarding table */
     struct xport *ovs_port = get_ofp_port(in_xbundle->xbridge,
                                           flow->in_port.ofp_port);
     struct mac_learning_info fdb_info;
     memset(&fdb_info, 0, sizeof(fdb_info));
-    if (ENABLE_OVS_P4_OFFLOAD) {
+    if (ovs_p4_offload_enabled()) {
         if (!get_fdb_data(ovs_port, flow->dl_src, &fdb_info)) {
             ConfigFdbTableEntry(fdb_info, true);
             ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
@@ -3258,6 +3260,7 @@ xlate_normal(struct xlate_ctx *ctx)
                      "P4 entry");
         }
     }
+    p4ovs_unlock(&p4ovs_fdb_entry_lock);
 #endif
 
     if (ctx->xin->xcache && in_xbundle != &ofpp_none_bundle) {
@@ -8528,7 +8531,7 @@ xlate_add_static_mac_entry(const struct ofproto_dpif *ofproto,
     }
 
 #if defined(P4OVS)
-    if (ENABLE_OVS_P4_OFFLOAD) {
+    if (ovs_p4_offload_enabled()) {
         /* Static MAC is configured, program P4 forwarding table */
         struct xport *ovs_port = get_ofp_port(xbundle->xbridge,
                                               in_port);

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -73,8 +73,10 @@
 #include "vlan-bitmap.h"
 
 #if defined(P4OVS)
-#include "openvswitch/ovs-p4rt.h"
 #include <netinet/ether.h>
+
+#include "openvswitch/ovs-p4rt.h"
+#include "openvswitch/p4ovs.h"
 
 static int32_t
 get_tunnel_data(struct netdev *netdev,
@@ -82,7 +84,7 @@ get_tunnel_data(struct netdev *netdev,
 
 uint8_t last_p4_bridge_id_used = 0;
 uint32_t unique_tunnel_src_port = P4_VXLAN_SOURCE_PORT_OFFSET;
-
+struct ovs_mutex p4ovs_fdb_entry_lock = OVS_MUTEX_INITIALIZER;
 #endif
 
 VLOG_DEFINE_THIS_MODULE(bridge);
@@ -554,6 +556,10 @@ bridge_init(const char *remote)
     rstp_init();
     odp_execute_init();
 
+#if defined(P4OVS)
+    p4ovs_lock_init(&p4ovs_fdb_entry_lock);
+#endif
+
     ifaces_changed = seq_create();
     last_ifaces_changed = seq_read(ifaces_changed);
     ifnotifier = if_notifier_create(if_change_cb, NULL);
@@ -576,6 +582,10 @@ bridge_exit(bool delete_datapath)
     HMAP_FOR_EACH_SAFE (br, node, &all_bridges) {
         bridge_destroy(br, delete_datapath);
     }
+
+#if defined(P4OVS)
+    p4ovs_lock_destroy(&p4ovs_fdb_entry_lock);
+#endif
 
     ovsdb_idl_destroy(idl);
 }


### PR DESCRIPTION
Control OVS offload with an environment variable during runtime. If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else if OVS_P4_OFFLOAD is not set or OVS_P4_OFFLOAD is any value other than false, then by default enable OVS offload.