### PR TITLE
Delete p4 target rules when interface is deleted.

### DIFF
--- a/include/openvswitch/ovs-p4rt.h
+++ b/include/openvswitch/ovs-p4rt.h
@@ -94,8 +94,6 @@ extern void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
 extern void ConfigSrcPortTableEntry(struct src_port_info vsi_sp,
                                     bool insert_entry);
 extern void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry);
-extern void ConfigIpTunnelTermTableEntry(struct tunnel_info tunnel_info,
-                                         bool insert_entry);
 extern void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
                                         bool insert_entry);
 

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -3245,13 +3245,13 @@ xlate_normal(struct xlate_ctx *ctx)
     }
 
 #if defined(P4OVS)
-    p4ovs_lock(&p4ovs_fdb_entry_lock);
     /* Dynamic MAC is learnt, program P4 forwarding table */
     struct xport *ovs_port = get_ofp_port(in_xbundle->xbridge,
                                           flow->in_port.ofp_port);
     struct mac_learning_info fdb_info;
     memset(&fdb_info, 0, sizeof(fdb_info));
     if (ovs_p4_offload_enabled()) {
+        p4ovs_lock(&p4ovs_fdb_entry_lock);
         if (!get_fdb_data(ovs_port, flow->dl_src, &fdb_info)) {
             ConfigFdbTableEntry(fdb_info, true);
             ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
@@ -3259,8 +3259,8 @@ xlate_normal(struct xlate_ctx *ctx)
             VLOG_DBG("Error retrieving FDB information, skipping programming "
                      "P4 entry");
         }
+        p4ovs_unlock(&p4ovs_fdb_entry_lock);
     }
-    p4ovs_unlock(&p4ovs_fdb_entry_lock);
 #endif
 
     if (ctx->xin->xcache && in_xbundle != &ofpp_none_bundle) {


### PR DESCRIPTION
We are not handling all delete port notifications as the OVSD configuration will be invalid/NULL when we receive delete of multiple bridges, ports in a single transaction.
During delete path we are not looking for interface DB cfg, process delete notification with internal structures irrespective of iface->cfg is valid or not