### PR TITLE
Introduce option to specify grpc server address for ovs-p4rt

### DIFF
--- a/include/openvswitch/ovs-p4rt.h
+++ b/include/openvswitch/ovs-p4rt.h
@@ -101,21 +101,21 @@ struct ip_mac_map_info {
 
 // Function declarations
 extern void ConfigFdbTableEntry(struct mac_learning_info learn_info,
-                                bool insert_entry);
+                                bool insert_entry, const char* grpc_addr);
 extern void ConfigTunnelTableEntry(struct tunnel_info tunnel_info,
-                                   bool insert_entry);
+                                   bool insert_entry, const char* grpc_addr);
 extern void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
-                                          bool insert_entry);
+                                          bool insert_entry, const char* grpc_addr);
 extern void ConfigSrcPortTableEntry(struct src_port_info vsi_sp,
-                                    bool insert_entry);
-extern void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry);
+                                    bool insert_entry, const char* grpc_addr);
+extern void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry, const char* grpc_addr);
 extern void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
-                                        bool insert_entry);
+                                        bool insert_entry, const char* grpc_addr);
 
 extern enum ovs_tunnel_type TunnelTypeStrtoEnum(const char* tnl_type);
 
 extern void ConfigIpMacMapTableEntry(struct ip_mac_map_info learn_info,
-                                     bool insert_entry);
+                                     bool insert_entry, const char* grpc_addr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/openvswitch/p4ovs.h
+++ b/include/openvswitch/p4ovs.h
@@ -10,7 +10,9 @@
 #define OPENVSWITCH_P4OVS_H
 
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
+
 #include "openvswitch/thread.h"
 #include "openvswitch/util.h"
 
@@ -20,7 +22,7 @@ extern "C" {
 
 extern struct ovs_mutex p4ovs_fdb_entry_lock;
 
-extern char grpc_addr[32]; // Size is 32
+extern const char grpc_addr[32];
 
 /* Control OvS offload with an environment variable during runtime.
  * If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else
@@ -54,6 +56,8 @@ static inline void p4ovs_lock(const struct ovs_mutex *p4ovs_lock) {
 static inline void p4ovs_unlock(const struct ovs_mutex *p4ovs_lock) {
     return ovs_mutex_unlock(p4ovs_lock) OVS_RELEASES(p4ovs_lock);
 }
+
+void ovs_set_grpc_addr(const char* optarg);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/openvswitch/p4ovs.h
+++ b/include/openvswitch/p4ovs.h
@@ -22,7 +22,7 @@ extern "C" {
 
 extern struct ovs_mutex p4ovs_fdb_entry_lock;
 
-extern const char grpc_addr[32];
+extern char grpc_addr[32];
 
 /* Control OvS offload with an environment variable during runtime.
  * If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else

--- a/include/openvswitch/p4ovs.h
+++ b/include/openvswitch/p4ovs.h
@@ -10,13 +10,17 @@
 #define OPENVSWITCH_P4OVS_H
 
 #include <stdint.h>
+#include <string.h>
 #include "openvswitch/thread.h"
+#include "openvswitch/util.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 extern struct ovs_mutex p4ovs_fdb_entry_lock;
+
+extern char grpc_addr[32]; // Size is 32
 
 /* Control OvS offload with an environment variable during runtime.
  * If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else

--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -452,19 +452,11 @@ mac_learning_del_static_entry(struct mac_learning *ml,
  *
  * Keep the code here synchronized with that in update_learning_table__()
  * below. */
-#if defined(P4OVS)
 bool
 is_mac_learning_update_needed(const struct mac_learning *ml,
                               struct eth_addr src, int vlan,
                               bool is_gratuitous_arp, bool is_bond,
                               void *in_port)
-#else
-static bool
-is_mac_learning_update_needed(const struct mac_learning *ml,
-                              struct eth_addr src, int vlan,
-                              bool is_gratuitous_arp, bool is_bond,
-                              void *in_port)
-#endif
     OVS_REQ_RDLOCK(ml->rwlock)
 {
     struct mac_entry *mac;

--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015 Nicira, Inc.
+ * Copyright (c) 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -463,7 +464,7 @@ is_mac_learning_update_needed(const struct mac_learning *ml,
                               struct eth_addr src, int vlan,
                               bool is_gratuitous_arp, bool is_bond,
                               void *in_port)
-#endif	
+#endif
     OVS_REQ_RDLOCK(ml->rwlock)
 {
     struct mac_entry *mac;

--- a/lib/mac-learning.h
+++ b/lib/mac-learning.h
@@ -229,6 +229,14 @@ bool mac_learning_may_learn(const struct mac_learning *ml,
                             const struct eth_addr src_mac,
                             uint16_t vlan)
     OVS_REQ_RDLOCK(ml->rwlock);
+#if defined(P4OVS)
+bool
+is_mac_learning_update_needed(const struct mac_learning *ml,
+                              struct eth_addr src, int vlan,
+                              bool is_gratuitous_arp, bool is_bond,
+                              void *in_port)
+    OVS_REQ_RDLOCK(ml->rwlock);
+#endif    
 struct mac_entry *mac_learning_insert(struct mac_learning *ml,
                                       const struct eth_addr src,
                                       uint16_t vlan)

--- a/lib/mac-learning.h
+++ b/lib/mac-learning.h
@@ -229,14 +229,12 @@ bool mac_learning_may_learn(const struct mac_learning *ml,
                             const struct eth_addr src_mac,
                             uint16_t vlan)
     OVS_REQ_RDLOCK(ml->rwlock);
-#if defined(P4OVS)
 bool
 is_mac_learning_update_needed(const struct mac_learning *ml,
                               struct eth_addr src, int vlan,
                               bool is_gratuitous_arp, bool is_bond,
                               void *in_port)
     OVS_REQ_RDLOCK(ml->rwlock);
-#endif    
 struct mac_entry *mac_learning_insert(struct mac_learning *ml,
                                       const struct eth_addr src,
                                       uint16_t vlan)

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -75,6 +75,7 @@
 #include <sys/ioctl.h>
 #include "openvswitch/ovs-p4rt.h"
 #include "openvswitch/p4ovs.h"
+bool is_mac_learn_required = false;
 #endif //P4OVS
 
 COVERAGE_DEFINE(xlate_actions);
@@ -3277,51 +3278,58 @@ xlate_normal(struct xlate_ctx *ctx)
         && flow->packet_type == htonl(PT_ETH)
         && in_port && in_port->pt_mode != NETDEV_PT_LEGACY_L3
     ) {
+#if defined(P4OVS)
+        is_mac_learn_required = is_mac_learning_update_needed(ctx->xbridge->ml,
+                                flow->dl_src, vlan,is_grat_arp,
+                                in_xbundle->bond != NULL,
+                                in_xbundle->ofbundle);
+#endif        
         //The function below calls mac_learning_insert
         update_learning_table(ctx, in_xbundle, flow->dl_src, vlan,
                               is_grat_arp);
     }
 
 #if defined(P4OVS)
-    /* Dynamic MAC is learnt, program P4 forwarding table */
-    struct xport *ovs_port = get_ofp_port(in_xbundle->xbridge,
-                                          flow->in_port.ofp_port);
-    struct mac_learning_info fdb_info;
-    memset(&fdb_info, 0, sizeof(fdb_info));
-    if (ovs_p4_offload_enabled()) {
-        p4ovs_lock(&p4ovs_fdb_entry_lock);
-        if (!get_fdb_data(ovs_port, flow->dl_src, &fdb_info)) {
-            ConfigFdbTableEntry(fdb_info, true);
-            ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
-        } else {
-            VLOG_DBG("Error retrieving FDB information, skipping programming "
-                     "P4 entry");
-        }
-        p4ovs_unlock(&p4ovs_fdb_entry_lock);
+    if (is_mac_learn_required) {
+       /* Dynamic MAC is learnt, program P4 forwarding table */
+       struct xport *ovs_port = get_ofp_port(in_xbundle->xbridge,
+                                             flow->in_port.ofp_port);
+       struct mac_learning_info fdb_info;
+       memset(&fdb_info, 0, sizeof(fdb_info));
+       if (ovs_p4_offload_enabled()) {
+           p4ovs_lock(&p4ovs_fdb_entry_lock);
+           if (!get_fdb_data(ovs_port, flow->dl_src, &fdb_info)) {
+               ConfigFdbTableEntry(fdb_info, true, grpc_addr);
+               ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
+           } else {
+               VLOG_DBG("Error retrieving FDB information, skipping programming "
+                        "P4 entry");
+           }
+           p4ovs_unlock(&p4ovs_fdb_entry_lock);
+       }
+   
+          // Update the recently added MAC entry with flow info
+          struct mac_entry *e;
+   
+          ovs_rwlock_wrlock(&ctx->xbridge->ml->rwlock);
+          e = mac_learning_lookup(ctx->xbridge->ml, flow->dl_src, vlan);
+          if (e) {
+              e->nw_src = flow->nw_src;
+              e->nw_dst = flow->nw_dst;
+             //TODO: Update IPv6 info in MAC entry when IPv6 support is added
+          }
+          ovs_rwlock_unlock(&ctx->xbridge->ml->rwlock);
+   
+          if (ovs_p4_offload_enabled()) {
+             struct ip_mac_map_info ip_info;
+             memset(&ip_info, 0, sizeof(ip_info));
+             if (update_ip_mac_map_info(flow, &ip_info)) {
+                ConfigIpMacMapTableEntry(ip_info, true, grpc_addr);
+             }
+          } else {
+             VLOG_DBG("P4 offload disabled, skipping programming ");
+          }
     }
-
-    // Update the recently added MAC entry with flow info
-    struct mac_entry *e;
-
-    ovs_rwlock_wrlock(&ctx->xbridge->ml->rwlock);
-    e = mac_learning_lookup(ctx->xbridge->ml, flow->dl_src, vlan);
-    if (e) {
-        e->nw_src = flow->nw_src;
-        e->nw_dst = flow->nw_dst;
-     //TODO: Update IPv6 info in MAC entry when IPv6 support is added
-     }
-     ovs_rwlock_unlock(&ctx->xbridge->ml->rwlock);
-
-    if (ovs_p4_offload_enabled()) {
-        struct ip_mac_map_info ip_info;
-        memset(&ip_info, 0, sizeof(ip_info));
-        if (update_ip_mac_map_info(flow, &ip_info)) {
-           ConfigIpMacMapTableEntry(ip_info, true);
-        }
-    } else {
-        VLOG_DBG("P4 offload disabled, skipping programming ");
-    }
-
 #endif
 
     if (ctx->xin->xcache && in_xbundle != &ofpp_none_bundle) {
@@ -8600,7 +8608,7 @@ xlate_add_static_mac_entry(const struct ofproto_dpif *ofproto,
         memset(&fdb_info, 0, sizeof(fdb_info));
 
         if (!get_fdb_data(ovs_port, dl_src, &fdb_info)) {
-            ConfigFdbTableEntry(fdb_info, true);
+            ConfigFdbTableEntry(fdb_info, true, grpc_addr);
             ofproto->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
         } else {
             VLOG_DBG("Error retrieving FDB information, skipping programming "

--- a/vswitchd/automake.mk
+++ b/vswitchd/automake.mk
@@ -11,6 +11,10 @@ vswitchd_sources = \
 	vswitchd/system-stats.h
 
 if P4OVS
+vswitchd_sources += vswitchd/p4ovs.c
+endif
+
+if P4OVS
 # Build a static library instead of an executable.
 lib_LTLIBRARIES += vswitchd/libvswitchd.la
 

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -85,7 +85,6 @@ get_tunnel_data(struct netdev *netdev,
 uint8_t last_p4_bridge_id_used = 0;
 uint32_t unique_tunnel_src_port = P4_VXLAN_SOURCE_PORT_OFFSET;
 struct ovs_mutex p4ovs_fdb_entry_lock = OVS_MUTEX_INITIALIZER;
-//extern char grpc_addr[];
 #endif
 
 VLOG_DEFINE_THIS_MODULE(bridge);

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -85,6 +85,7 @@ get_tunnel_data(struct netdev *netdev,
 uint8_t last_p4_bridge_id_used = 0;
 uint32_t unique_tunnel_src_port = P4_VXLAN_SOURCE_PORT_OFFSET;
 struct ovs_mutex p4ovs_fdb_entry_lock = OVS_MUTEX_INITIALIZER;
+//extern char grpc_addr[];
 #endif
 
 VLOG_DEFINE_THIS_MODULE(bridge);
@@ -2233,8 +2234,8 @@ ConfigureP4Target(struct bridge *br, struct port *port,
             tnl_info.bridge_id = br->p4_bridge_id;
             tnl_info.src_port = port->p4_src_port;
 
-            ConfigTunnelTableEntry(tnl_info, insert_entry);
-            ConfigRxTunnelSrcTableEntry(tnl_info, insert_entry);
+            ConfigTunnelTableEntry(tnl_info, insert_entry, grpc_addr);
+            ConfigRxTunnelSrcTableEntry(tnl_info, insert_entry, grpc_addr);
         } else {
             VLOG_ERR("Error retrieving tunnel information, "
                      "skipping programming P4 entry");
@@ -2249,15 +2250,15 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_vlan_id,
                                                       port->p4_src_port};
             /* When VLAN tag is configured */
-            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry);
-            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry);
+            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry, grpc_addr);
+            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry, grpc_addr);
         } else {
             /* Wild card VLAN 0 */
             struct src_port_info tnl_src_port_info = {br->p4_bridge_id,
                                                       0,
                                                       port->p4_src_port};
 
-            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry);
+            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry, grpc_addr);
         }
         port->is_src_port_configured = insert_entry;
     } else if (!insert_entry || iface->cfg->mac_in_use) {
@@ -2277,8 +2278,8 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_vlan_id,
                                                       port->p4_src_port};
 
-            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry);
-            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry);
+            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry, grpc_addr);
+            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry, grpc_addr);
         } else if (port->p4_vlan_mode == P4_PORT_VLAN_UNSUPPORTED) {
             /* Do nothing, unsupported vlan mode */
         } else if (port->p4_src_port) {
@@ -2286,7 +2287,7 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       0,
                                                       port->p4_src_port};
 
-            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry);
+            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry, grpc_addr);
         } else {
             VLOG_DBG("Invalid P4 use case for source port to "
                      "bridge mapping");

--- a/vswitchd/ovs-vswitchd.c
+++ b/vswitchd/ovs-vswitchd.c
@@ -191,7 +191,9 @@ parse_options(int argc, char *argv[], char **unixctl_pathp)
         {"disable-system-route", no_argument, NULL, OPT_DISABLE_SYSTEM_ROUTE},
         {"dpdk", optional_argument, NULL, OPT_DPDK},
         {"dummy-numa", required_argument, NULL, OPT_DUMMY_NUMA},
+#if defined(P4OVS)
         {"grpc-addr", optional_argument, NULL, 'g'},
+#endif
         {NULL, 0, NULL, 0},
     };
     char *short_options = ovs_cmdl_long_options_to_short_options(long_options);
@@ -212,12 +214,6 @@ parse_options(int argc, char *argv[], char **unixctl_pathp)
             ovs_print_version(0, 0);
             print_dpdk_version();
             exit(EXIT_SUCCESS);
-
-        case 'g':
-            memset(grpc_addr, 0, sizeof(grpc_addr));
-            strncpy(grpc_addr, optarg, sizeof(optarg));
-            strcat(grpc_addr, ":9559");
-            break;
 
         case OPT_MLOCKALL:
             want_mlockall = true;
@@ -261,6 +257,13 @@ parse_options(int argc, char *argv[], char **unixctl_pathp)
         case OPT_DUMMY_NUMA:
             ovs_numa_set_dummy(optarg);
             break;
+
+#if defined(P4OVS)
+        case OPT_GRPC_ADDR:
+        case 'g':
+            ovs_set_grpc_addr(optarg);
+            break;
+#endif
 
         default:
             abort();

--- a/vswitchd/ovs-vswitchd.c
+++ b/vswitchd/ovs-vswitchd.c
@@ -53,6 +53,9 @@
 #include "openvswitch/vlog.h"
 #include "lib/vswitch-idl.h"
 #include "lib/dns-resolve.h"
+#if defined(P4OVS)
+#include "openvswitch/p4ovs.h"
+#endif
 
 VLOG_DEFINE_THIS_MODULE(vswitchd);
 
@@ -169,6 +172,9 @@ parse_options(int argc, char *argv[], char **unixctl_pathp)
         OPT_DPDK,
         SSL_OPTION_ENUMS,
         OPT_DUMMY_NUMA,
+#if defined(P4OVS)
+        OPT_GRPC_ADDR,
+#endif
     };
     static const struct option long_options[] = {
         {"help",        no_argument, NULL, 'h'},
@@ -185,6 +191,7 @@ parse_options(int argc, char *argv[], char **unixctl_pathp)
         {"disable-system-route", no_argument, NULL, OPT_DISABLE_SYSTEM_ROUTE},
         {"dpdk", optional_argument, NULL, OPT_DPDK},
         {"dummy-numa", required_argument, NULL, OPT_DUMMY_NUMA},
+        {"grpc-addr", optional_argument, NULL, 'g'},
         {NULL, 0, NULL, 0},
     };
     char *short_options = ovs_cmdl_long_options_to_short_options(long_options);
@@ -205,6 +212,12 @@ parse_options(int argc, char *argv[], char **unixctl_pathp)
             ovs_print_version(0, 0);
             print_dpdk_version();
             exit(EXIT_SUCCESS);
+
+        case 'g':
+            memset(grpc_addr, 0, sizeof(grpc_addr));
+            strncpy(grpc_addr, optarg, sizeof(optarg));
+            strcat(grpc_addr, ":9559");
+            break;
 
         case OPT_MLOCKALL:
             want_mlockall = true;
@@ -289,6 +302,9 @@ usage(void)
     printf("\nOther options:\n"
            "  --unixctl=SOCKET          override default control socket name\n"
            "  -h, --help                display this help message\n"
+#if defined(P4OVS)
+           "  -g, --grpc-addr           gRPC server address for P4Runtime server\n"
+#endif   
            "  -V, --version             display version information\n");
     exit(EXIT_SUCCESS);
 }

--- a/vswitchd/p4ovs.c
+++ b/vswitchd/p4ovs.c
@@ -1,4 +1,25 @@
-#include <config.h>
-#include "openvswitch/p4ovs.h"
+/*
+ * Copyright (c) 2024 Intel Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-char grpc_addr[32] = "localhost:9559";
+#include <config.h>
+#include <string.h>
+
+#include "openvswitch/p4ovs.h"
+#include "util.h"
+
+const char grpc_addr[32] = "localhost:9559";
+static const char grpc_port[] = ":9559";
+
+void ovs_set_grpc_addr(const char* optarg) {
+    if (strlen(optarg) + sizeof(grpc_port) >= sizeof(grpc_addr)) {
+        ovs_fatal(0, "--grpc_addr is too long (> %lu characters)",
+                  sizeof(grpc_addr) - sizeof(grpc_port));
+    }
+    // grpc_addr is immutable except for this function.
+    // We must cast away const to initialize it.
+    strncpy((char *)grpc_addr, optarg, sizeof(grpc_addr));
+    strcat((char *)grpc_addr, grpc_port);
+}
+

--- a/vswitchd/p4ovs.c
+++ b/vswitchd/p4ovs.c
@@ -9,7 +9,7 @@
 #include "openvswitch/p4ovs.h"
 #include "util.h"
 
-const char grpc_addr[32] = "localhost:9559";
+char grpc_addr[32] = "localhost:9559";
 static const char grpc_port[] = ":9559";
 
 void ovs_set_grpc_addr(const char* optarg) {
@@ -17,9 +17,7 @@ void ovs_set_grpc_addr(const char* optarg) {
         ovs_fatal(0, "--grpc_addr is too long (> %lu characters)",
                   sizeof(grpc_addr) - sizeof(grpc_port));
     }
-    // grpc_addr is immutable except for this function.
-    // We must cast away const to initialize it.
-    strncpy((char *)grpc_addr, optarg, sizeof(grpc_addr));
-    strcat((char *)grpc_addr, grpc_port);
+    strncpy(grpc_addr, optarg, sizeof(grpc_addr));
+    strcat(grpc_addr, grpc_port);
 }
 

--- a/vswitchd/p4ovs.c
+++ b/vswitchd/p4ovs.c
@@ -1,0 +1,4 @@
+#include <config.h>
+#include "openvswitch/p4ovs.h"
+
+char grpc_addr[32] = "localhost:9559";


### PR DESCRIPTION
This patch does the following:
- Introduce the option to specify grpc server address for ovs-p4rt client. It can be specified using --grpc-addr or -g option when starting ovs-vswitchd
- Introduce checks to program FDB learnt entries to hardware only if it's a  new entry