### PR TITLE
Rename ovsp4rt public functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ testsuite.tmp.orig
 /Documentation/_build
 /.venv
 /cxx-check
+/.vscode/
+/.vslick/

--- a/include/ovsp4rt/ovs-p4rt.h
+++ b/include/ovsp4rt/ovs-p4rt.h
@@ -127,30 +127,33 @@ struct ip_mac_map_info {
 // Function prototypes
 //----------------------------------------------------------------------
 
-extern void ConfigFdbTableEntry(struct mac_learning_info learn_info,
-                                bool insert_entry, const char* grpc_addr);
-
-extern void ConfigIpMacMapTableEntry(struct ip_mac_map_info learn_info,
+extern void ovsp4rt_config_fdb_entry(struct mac_learning_info learn_info,
                                      bool insert_entry, const char* grpc_addr);
 
-extern void ConfigRxTunnelSrcTableEntry(struct tunnel_info tunnel_info,
-                                        bool insert_entry,
-                                        const char* grpc_addr);
+extern void ovsp4rt_config_ip_mac_map_entry(struct ip_mac_map_info learn_info,
+                                            bool insert_entry,
+                                            const char* grpc_addr);
 
-extern void ConfigSrcPortTableEntry(struct src_port_info vsi_sp,
-                                    bool insert_entry, const char* grpc_addr);
+extern void ovsp4rt_config_rx_tunnel_src_entry(struct tunnel_info tunnel_info,
+                                               bool insert_entry,
+                                               const char* grpc_addr);
 
-extern void ConfigTunnelSrcPortTableEntry(struct src_port_info tnl_sp,
+extern void ovsp4rt_config_src_port_entry(struct src_port_info vsi_sp,
                                           bool insert_entry,
                                           const char* grpc_addr);
 
-extern void ConfigTunnelTableEntry(struct tunnel_info tunnel_info,
-                                   bool insert_entry, const char* grpc_addr);
+extern void ovsp4rt_config_tunnel_src_port_entry(struct src_port_info tnl_sp,
+                                                 bool insert_entry,
+                                                 const char* grpc_addr);
 
-extern void ConfigVlanTableEntry(uint16_t vlan_id, bool insert_entry,
-                                 const char* grpc_addr);
+extern void ovsp4rt_config_tunnel_entry(struct tunnel_info tunnel_info,
+                                        bool insert_entry,
+                                        const char* grpc_addr);
 
-extern enum ovs_tunnel_type TunnelTypeStrtoEnum(const char* tnl_type);
+extern void ovsp4rt_config_vlan_entry(uint16_t vlan_id, bool insert_entry,
+                                      const char* grpc_addr);
+
+extern enum ovs_tunnel_type ovsp4rt_str_to_tunnel_type(const char* tnl_type);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -624,7 +624,7 @@ mac_learning_expire(struct mac_learning *ml, struct mac_entry *e)
         memcpy(fdb_info.mac_addr, e->mac.ea, sizeof(fdb_info.mac_addr));
         fdb_info.is_vlan = true;
         fdb_info.bridge_id = ml->p4_bridge_id;
-        ConfigFdbTableEntry(fdb_info, false, grpc_addr);
+        ovsp4rt_config_fdb_entry(fdb_info, false, grpc_addr);
 
         // Remove the corresponding ip_mac tables both for src ip and dst ip
         struct ip_mac_map_info ip_info;
@@ -634,7 +634,7 @@ mac_learning_expire(struct mac_learning *ml, struct mac_entry *e)
         ip_info.dst_ip_addr.family = AF_INET;
         ip_info.dst_ip_addr.ip.v4addr.s_addr = e->nw_dst;
         // TODO: Update IPv6 fields when IPv6 support is added
-        ConfigIpMacMapTableEntry(ip_info, false, grpc_addr);
+        ovsp4rt_config_ip_mac_map_entry(ip_info, false, grpc_addr);
     }
 #endif // P4OVS
     free(e);

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -3110,7 +3110,7 @@ get_fdb_data(struct xport *port, struct eth_addr mac_addr,
         fdb_info->tnl_info.dst_port = underlay_tnl->dst_port;
         fdb_info->tnl_info.vni = underlay_tnl->vni;
         const char *tnl_type = tnl_port_get_type(port->ofport);
-        fdb_info->tnl_info.tunnel_type = TunnelTypeStrtoEnum(tnl_type);
+        fdb_info->tnl_info.tunnel_type = ovsp4rt_str_to_tunnel_type(tnl_type);
 
         if (underlay_tnl->ipv6_src.__in6_u.__u6_addr32[0]) {
             /* IPv6 tunnel configuration */
@@ -3300,7 +3300,7 @@ xlate_normal(struct xlate_ctx *ctx)
        if (ovs_p4_offload_enabled()) {
            p4ovs_lock(&p4ovs_fdb_entry_lock);
            if (!get_fdb_data(ovs_port, flow->dl_src, &fdb_info)) {
-               ConfigFdbTableEntry(fdb_info, true, grpc_addr);
+               ovsp4rt_config_fdb_entry(fdb_info, true, grpc_addr);
                ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
            } else {
                VLOG_DBG("Error retrieving FDB information, skipping programming "
@@ -3324,7 +3324,7 @@ xlate_normal(struct xlate_ctx *ctx)
        if (ovs_p4_offload_enabled()) {
           struct ip_mac_map_info ip_info = {0};
           if (update_ip_mac_map_info(flow, &ip_info)) {
-             ConfigIpMacMapTableEntry(ip_info, true, grpc_addr);
+             ovsp4rt_config_ip_mac_map_entry(ip_info, true, grpc_addr);
           }
        } else {
           VLOG_DBG("P4 offload disabled, skipping programming ");
@@ -8608,7 +8608,7 @@ xlate_add_static_mac_entry(const struct ofproto_dpif *ofproto,
         memset(&fdb_info, 0, sizeof(fdb_info));
 
         if (!get_fdb_data(ovs_port, dl_src, &fdb_info)) {
-            ConfigFdbTableEntry(fdb_info, true, grpc_addr);
+            ovsp4rt_config_fdb_entry(fdb_info, true, grpc_addr);
             ofproto->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
         } else {
             VLOG_DBG("Error retrieving FDB information, skipping programming "

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -2160,7 +2160,7 @@ get_tunnel_data(struct netdev *netdev,
      tnl_info->vni = underlay_tnl->vni;
 
      const char* tnl_type = netdev_get_type(netdev);
-     tnl_info->tunnel_type = TunnelTypeStrtoEnum(tnl_type);
+     tnl_info->tunnel_type = ovsp4rt_str_to_tunnel_type(tnl_type);
 
      return 0;
 }
@@ -2233,8 +2233,9 @@ ConfigureP4Target(struct bridge *br, struct port *port,
             tnl_info.bridge_id = br->p4_bridge_id;
             tnl_info.src_port = port->p4_src_port;
 
-            ConfigTunnelTableEntry(tnl_info, insert_entry, grpc_addr);
-            ConfigRxTunnelSrcTableEntry(tnl_info, insert_entry, grpc_addr);
+            ovsp4rt_config_tunnel_entry(tnl_info, insert_entry, grpc_addr);
+            ovsp4rt_config_rx_tunnel_src_entry(tnl_info, insert_entry,
+                                               grpc_addr);
         } else {
             VLOG_ERR("Error retrieving tunnel information, "
                      "skipping programming P4 entry");
@@ -2249,15 +2250,18 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_vlan_id,
                                                       port->p4_src_port};
             /* When VLAN tag is configured */
-            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry, grpc_addr);
-            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry, grpc_addr);
+            ovsp4rt_config_vlan_entry(port->p4_vlan_id, insert_entry,
+                                      grpc_addr);
+            ovsp4rt_config_tunnel_src_port_entry(tnl_src_port_info,
+                                                 insert_entry, grpc_addr);
         } else {
             /* Wild card VLAN 0 */
             struct src_port_info tnl_src_port_info = {br->p4_bridge_id,
                                                       0,
                                                       port->p4_src_port};
 
-            ConfigTunnelSrcPortTableEntry(tnl_src_port_info, insert_entry, grpc_addr);
+            ovsp4rt_config_tunnel_src_port_entry(tnl_src_port_info,
+                                                 insert_entry, grpc_addr);
         }
         port->is_src_port_configured = insert_entry;
     } else if (!insert_entry || iface->cfg->mac_in_use) {
@@ -2277,8 +2281,10 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_vlan_id,
                                                       port->p4_src_port};
 
-            ConfigVlanTableEntry(port->p4_vlan_id, insert_entry, grpc_addr);
-            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry, grpc_addr);
+            ovsp4rt_config_vlan_entry(port->p4_vlan_id, insert_entry,
+                                      grpc_addr);
+            ovsp4rt_config_src_port_entry(vsi_src_port_info, insert_entry,
+                                          grpc_addr);
         } else if (port->p4_vlan_mode == P4_PORT_VLAN_UNSUPPORTED) {
             /* Do nothing, unsupported vlan mode */
         } else if (port->p4_src_port) {
@@ -2286,7 +2292,8 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       0,
                                                       port->p4_src_port};
 
-            ConfigSrcPortTableEntry(vsi_src_port_info, insert_entry, grpc_addr);
+            ovsp4rt_config_src_port_entry(vsi_src_port_info, insert_entry,
+                                          grpc_addr);
         } else {
             VLOG_DBG("Invalid P4 use case for source port to "
                      "bridge mapping");


### PR DESCRIPTION
- Renamed the functions that ovs-p4rt publishes for use by OVS to conform better to C naming conventions.

- Added .vscode/ and .vslick/ to .gitignore.

Must be merged before https://github.com/ipdk-io/networking-recipe/pull/485.