### PR TITLE
Housekeeping and bug fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 # Copyright (C) 2007-2017 Nicira, Inc.
+# Copyright (c) 2023-2024 Intel Corporation.
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Nicira, Inc.
-# Copyright (c) 2021 Intel Corporation.
+# Copyright (c) 2021-2022 Intel Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/include/openvswitch/p4ovs.h
+++ b/include/openvswitch/p4ovs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Intel Corporation.
+ * Copyright (c) 2023-2024 Intel Corporation.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Defines the P4 OvS specific definitions. These need be used under

--- a/lib/dpif-netlink-rtnl.c
+++ b/lib/dpif-netlink-rtnl.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2017 Red Hat, Inc.
- * Copyright (c) 2021 Intel Corporation.
+ * Copyright (c) 2021-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/mac-learning.h
+++ b/lib/mac-learning.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2015 Nicira, Inc.
+ * Copyright (c) 2023-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/netdev-vport.c
+++ b/lib/netdev-vport.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010, 2011, 2012, 2013, 2014, 2017 Nicira, Inc.
  * Copyright (c) 2016 Red Hat, Inc.
- * Copyright (c) 2021 Intel Corporation.
+ * Copyright (c) 2021-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -663,10 +663,14 @@ set_tunnel_config(struct netdev *dev_, const struct smap *args, char **errp)
             if (!strcmp(node->value, "false")) {
                 tnl_cfg.dont_fragment = false;
             }
-        } else if (!strcmp(node->key, "key") && strcmp(node->value, "flow")) {
+#if defined(P4OVS)
+        } else if (!strcmp(node->key, "key") &&
+                   strcmp(node->value, "flow")) {
             /* Add VNI to tunnel config if the value is not flow */
             tnl_cfg.vni = atoi(node->value);
-        } else if (!strcmp(node->key, "in_key") ||
+#endif
+        } else if (!strcmp(node->key, "key") ||
+                   !strcmp(node->key, "in_key") ||
                    !strcmp(node->key, "out_key") ||
                    !strcmp(node->key, "packet_type")) {
             /* Handled separately below. */

--- a/lib/netdev.h
+++ b/lib/netdev.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013 Nicira, Inc.
- * Copyright (c) 2021 Intel Corporation.
+ * Copyright (c) 2021-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,7 +142,9 @@ struct netdev_tunnel_config {
     bool erspan_dir_flow;
     bool erspan_hwid_flow;
 
+#if defined(P4OVS)
     uint32_t vni;
+#endif
 };
 
 void netdev_run(void);

--- a/lib/util.h
+++ b/lib/util.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Nicira, Inc.
+ * Copyright (c) 2021-2022 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ofproto/ofproto-dpif-xlate.h
+++ b/ofproto/ofproto-dpif-xlate.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Nicira, Inc.
+ * Copyright (c) 2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +191,7 @@ void xlate_bundle_set(struct ofproto_dpif *, struct ofbundle *,
                       enum port_priority_tags_mode,
                       const struct bond *, const struct lacp *,
                       bool floodable, bool protected, uint8_t p4_bridge_id);
-#elif
+#else
 void xlate_bundle_set(struct ofproto_dpif *, struct ofbundle *,
                       const char *name, enum port_vlan_mode,
                       uint16_t qinq_ethtype, int vlan,

--- a/ofproto/ofproto-dpif.c
+++ b/ofproto/ofproto-dpif.c
@@ -1,4 +1,5 @@
-/*
+/* [no original copyright notice]
+ * Copyright (c) 2022-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -499,7 +500,7 @@ type_run(const char *type)
                                  bundle->bond, bundle->lacp,
                                  bundle->floodable, bundle->protected,
                                  bundle->p4_bridge_id);
-#elif
+#else
                 xlate_bundle_set(ofproto, bundle, bundle->name,
                                  bundle->vlan_mode, bundle->qinq_ethtype,
                                  bundle->vlan, bundle->trunks, bundle->cvlans,

--- a/ofproto/ofproto.h
+++ b/ofproto/ofproto.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Nicira, Inc.
+ * Copyright (c) 2023 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +23,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
 #include "cfm.h"
 #include "classifier.h"
 #include "flow.h"

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017 Nicira, Inc.
+ * Copyright (c) 2023-2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vswitchd/ovs-vswitchd.c
+++ b/vswitchd/ovs-vswitchd.c
@@ -1,4 +1,5 @@
 /* Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016 Nicira, Inc.
+ * Copyright (c) 2024 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
1. Added or updated Intel copyright notices.

2. Corrected `#elif` directives to `#else` in `ofproto-dpif-xlate`.

3. Added missing P4OVS conditionals in `netdev.h` and `netdev-vport.c`.

4. Removed trailing whitespace.

Changes 2 and 3 fix compilation errors.

Change 3 fixes the eight unit tests that used to fail.