### PR TITLE
Manually terminate grpc addr string to address Coverity hit

### DIFF
--- a/vswitchd/p4ovs.c
+++ b/vswitchd/p4ovs.c
@@ -13,12 +13,15 @@ char grpc_addr[32] = "localhost:9559";
 static const char grpc_port[] = ":9559";
 
 void ovs_set_grpc_addr(const char* optarg) {
-    if (strlen(optarg) + sizeof(grpc_port) >= sizeof(grpc_addr)) {
-        ovs_fatal(0, "--grpc_addr is too long (> %lu characters)",
-                  sizeof(grpc_addr) - sizeof(grpc_port));
+    size_t maximum = sizeof(grpc_addr) - strlen(grpc_port) - 1;
+    size_t actual = strlen(optarg);
+
+    if (actual > maximum) {
+        ovs_fatal(0, "--grpc-addr (%lu chars) is too long (> %lu chars)",
+                  actual, maximum);
     }
-    strncpy(grpc_addr, optarg, sizeof(grpc_addr) - 1);
-    grpc_addr[sizeof(grpc_addr) - 1] = '\0';
+
+    strncpy(grpc_addr, optarg, sizeof(grpc_addr));
     strcat(grpc_addr, grpc_port);
 }
 

--- a/vswitchd/p4ovs.c
+++ b/vswitchd/p4ovs.c
@@ -17,7 +17,8 @@ void ovs_set_grpc_addr(const char* optarg) {
         ovs_fatal(0, "--grpc_addr is too long (> %lu characters)",
                   sizeof(grpc_addr) - sizeof(grpc_port));
     }
-    strncpy(grpc_addr, optarg, sizeof(grpc_addr));
+    strncpy(grpc_addr, optarg, sizeof(grpc_addr) - 1);
+    grpc_addr[sizeof(grpc_addr) - 1] = '\0';
     strcat(grpc_addr, grpc_port);
 }
 


### PR DESCRIPTION
Following Coverity hit was raised on stringcpy(). This PR fixes in order to avoid buffer overflow

> CID 2023675: (#undefined of undefined): Buffer not null terminated (BUFFER_SIZE)
> 2. buffer_size_warning Calling strncpy with a maximum size argument of 32 bytes on destination array grpc_addr of size 32 bytes might leave the destination string unterminated.
> 