### PR TITLE
Revise coverity fix

### DIFF
--- a/vswitchd/p4ovs.c
+++ b/vswitchd/p4ovs.c
@@ -13,12 +13,15 @@ char grpc_addr[32] = "localhost:9559";
 static const char grpc_port[] = ":9559";
 
 void ovs_set_grpc_addr(const char* optarg) {
-    if (strlen(optarg) + sizeof(grpc_port) >= sizeof(grpc_addr)) {
-        ovs_fatal(0, "--grpc_addr is too long (> %lu characters)",
-                  sizeof(grpc_addr) - sizeof(grpc_port));
+    size_t maximum = sizeof(grpc_addr) - strlen(grpc_port) - 1;
+    size_t actual = strlen(optarg);
+
+    if (actual > maximum) {
+        ovs_fatal(0, "--grpc-addr (%lu chars) is too long (> %lu chars)",
+                  actual, maximum);
     }
-    strncpy(grpc_addr, optarg, sizeof(grpc_addr) - 1);
-    grpc_addr[sizeof(grpc_addr) - 1] = '\0';
+
+    strncpy(grpc_addr, optarg, sizeof(grpc_addr));
     strcat(grpc_addr, grpc_port);
 }
 


### PR DESCRIPTION
- Corrected length check preceding strncpy().
- Revised error message to provide more information.