### PR TITLE
Update ovs-p4rt.h infrastructure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -200,7 +200,7 @@ dist-hook-git: distfiles
 	@if test -e $(srcdir)/.git && (git --version) >/dev/null 2>&1; then \
 	  (cd $(srcdir) && git ls-files) | grep -v '\.gitignore$$' | \
 	    grep -v '\.gitattributes$$' | grep -v 'CODEOWNERS' | \
-	    grep -v 'openvswitch/ovs-p4rt.h' | \
+	    grep -v 'ovsp4rt/ovs-p4rt.h' | \
 	    LC_ALL=C sort -u > all-gitfiles; \
 	  LC_ALL=C comm -1 -3 distfiles all-gitfiles > missing-distfiles; \
 	  if test -s missing-distfiles; then \

--- a/include/openvswitch/ovs-p4rt.h
+++ b/include/openvswitch/ovs-p4rt.h
@@ -1,1 +1,0 @@
-../ovsp4rt/ovs-p4rt.h

--- a/include/ovsp4rt/automake.mk
+++ b/include/ovsp4rt/automake.mk
@@ -2,8 +2,4 @@ if P4OVS
 ovsp4rtincludedir = $(includedir)/ovsp4rt
 ovsp4rtinclude_HEADERS = \
 	include/ovsp4rt/ovs-p4rt.h
-
-install-data-hook:
-	cd $(DESTDIR)$(includedir)/openvswitch && \
-	    $(LN_S) ../ovsp4rt/ovs-p4rt.h ovs-p4rt.h
 endif


### PR DESCRIPTION
- Removed symbolic link from `include/openvswitch/ovs-p4rt.h` to `include/ovsp4rt/ovs-p4rt.h`.

This CL is part of preparation for upstreaming.