### PR TITLE
Rename grpc_addr to p4ovs_grpc_addr

### DIFF
--- a/include/openvswitch/p4ovs.h
+++ b/include/openvswitch/p4ovs.h
@@ -22,7 +22,7 @@ extern "C" {
 
 extern struct ovs_mutex p4ovs_fdb_entry_lock;
 
-extern char grpc_addr[32];
+extern char p4ovs_grpc_addr[32];
 
 /* Control OvS offload with an environment variable during runtime.
  * If env variable OVS_P4_OFFLOAD=false, then disable OVS offload, else

--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -624,7 +624,7 @@ mac_learning_expire(struct mac_learning *ml, struct mac_entry *e)
         memcpy(fdb_info.mac_addr, e->mac.ea, sizeof(fdb_info.mac_addr));
         fdb_info.is_vlan = true;
         fdb_info.bridge_id = ml->p4_bridge_id;
-        ovsp4rt_config_fdb_entry(fdb_info, false, grpc_addr);
+        ovsp4rt_config_fdb_entry(fdb_info, false, p4ovs_grpc_addr);
 
         // Remove the corresponding ip_mac tables both for src ip and dst ip
         struct ip_mac_map_info ip_info;
@@ -634,7 +634,7 @@ mac_learning_expire(struct mac_learning *ml, struct mac_entry *e)
         ip_info.dst_ip_addr.family = AF_INET;
         ip_info.dst_ip_addr.ip.v4addr.s_addr = e->nw_dst;
         // TODO: Update IPv6 fields when IPv6 support is added
-        ovsp4rt_config_ip_mac_map_entry(ip_info, false, grpc_addr);
+        ovsp4rt_config_ip_mac_map_entry(ip_info, false, p4ovs_grpc_addr);
     }
 #endif // P4OVS
     free(e);

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -3304,7 +3304,7 @@ xlate_normal(struct xlate_ctx *ctx)
        if (ovs_p4_offload_enabled()) {
            p4ovs_lock(&p4ovs_fdb_entry_lock);
            if (!get_fdb_data(ovs_port, flow->dl_src, &fdb_info)) {
-               ovsp4rt_config_fdb_entry(fdb_info, true, grpc_addr);
+               ovsp4rt_config_fdb_entry(fdb_info, true, p4ovs_grpc_addr);
                ctx->xbridge->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
            } else {
                VLOG_DBG("Error retrieving FDB information, skipping programming "
@@ -3328,7 +3328,7 @@ xlate_normal(struct xlate_ctx *ctx)
        if (ovs_p4_offload_enabled()) {
           struct ip_mac_map_info ip_info = {0};
           if (update_ip_mac_map_info(flow, &ip_info)) {
-             ovsp4rt_config_ip_mac_map_entry(ip_info, true, grpc_addr);
+             ovsp4rt_config_ip_mac_map_entry(ip_info, true, p4ovs_grpc_addr);
           }
        } else {
           VLOG_DBG("P4 offload disabled, skipping programming ");
@@ -8612,7 +8612,7 @@ xlate_add_static_mac_entry(const struct ofproto_dpif *ofproto,
         memset(&fdb_info, 0, sizeof(fdb_info));
 
         if (!get_fdb_data(ovs_port, dl_src, &fdb_info)) {
-            ovsp4rt_config_fdb_entry(fdb_info, true, grpc_addr);
+            ovsp4rt_config_fdb_entry(fdb_info, true, p4ovs_grpc_addr);
             ofproto->ml->p4_bridge_id = ovs_port->xbundle->p4_bridge_id;
         } else {
             VLOG_DBG("Error retrieving FDB information, skipping programming "

--- a/vswitchd/bridge.c
+++ b/vswitchd/bridge.c
@@ -2234,9 +2234,9 @@ ConfigureP4Target(struct bridge *br, struct port *port,
             tnl_info.bridge_id = br->p4_bridge_id;
             tnl_info.src_port = port->p4_src_port;
 
-            ovsp4rt_config_tunnel_entry(tnl_info, insert_entry, grpc_addr);
+            ovsp4rt_config_tunnel_entry(tnl_info, insert_entry, p4ovs_grpc_addr);
             ovsp4rt_config_rx_tunnel_src_entry(tnl_info, insert_entry,
-                                               grpc_addr);
+                                               p4ovs_grpc_addr);
         } else {
             VLOG_ERR("Error retrieving tunnel information, "
                      "skipping programming P4 entry");
@@ -2252,9 +2252,9 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_src_port};
             /* When VLAN tag is configured */
             ovsp4rt_config_vlan_entry(port->p4_vlan_id, insert_entry,
-                                      grpc_addr);
+                                      p4ovs_grpc_addr);
             ovsp4rt_config_tunnel_src_port_entry(tnl_src_port_info,
-                                                 insert_entry, grpc_addr);
+                                                 insert_entry, p4ovs_grpc_addr);
         } else {
             /* Wild card VLAN 0 */
             struct src_port_info tnl_src_port_info = {br->p4_bridge_id,
@@ -2262,7 +2262,7 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_src_port};
 
             ovsp4rt_config_tunnel_src_port_entry(tnl_src_port_info,
-                                                 insert_entry, grpc_addr);
+                                                 insert_entry, p4ovs_grpc_addr);
         }
         port->is_src_port_configured = insert_entry;
     } else if (!insert_entry || iface->cfg->mac_in_use) {
@@ -2283,9 +2283,9 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_src_port};
 
             ovsp4rt_config_vlan_entry(port->p4_vlan_id, insert_entry,
-                                      grpc_addr);
+                                      p4ovs_grpc_addr);
             ovsp4rt_config_src_port_entry(vsi_src_port_info, insert_entry,
-                                          grpc_addr);
+                                          p4ovs_grpc_addr);
         } else if (port->p4_vlan_mode == P4_PORT_VLAN_UNSUPPORTED) {
             /* Do nothing, unsupported vlan mode */
         } else if (port->p4_src_port) {
@@ -2294,7 +2294,7 @@ ConfigureP4Target(struct bridge *br, struct port *port,
                                                       port->p4_src_port};
 
             ovsp4rt_config_src_port_entry(vsi_src_port_info, insert_entry,
-                                          grpc_addr);
+                                          p4ovs_grpc_addr);
         } else {
             VLOG_DBG("Invalid P4 use case for source port to "
                      "bridge mapping");

--- a/vswitchd/p4ovs.c
+++ b/vswitchd/p4ovs.c
@@ -9,15 +9,15 @@
 #include "openvswitch/p4ovs.h"
 #include "util.h"
 
-char grpc_addr[32] = "localhost:9559";
+char p4ovs_grpc_addr[32] = "localhost:9559";
 static const char grpc_port[] = ":9559";
 
 void ovs_set_grpc_addr(const char* optarg) {
-    if (strlen(optarg) + sizeof(grpc_port) >= sizeof(grpc_addr)) {
+    if (strlen(optarg) + sizeof(grpc_port) >= sizeof(p4ovs_grpc_addr)) {
         ovs_fatal(0, "--grpc_addr is too long (> %lu characters)",
-                  sizeof(grpc_addr) - sizeof(grpc_port));
+                  sizeof(p4ovs_grpc_addr) - sizeof(grpc_port));
     }
-    strncpy(grpc_addr, optarg, sizeof(grpc_addr));
-    strcat(grpc_addr, grpc_port);
+    strncpy(p4ovs_grpc_addr, optarg, sizeof(p4ovs_grpc_addr));
+    strcat(p4ovs_grpc_addr, grpc_port);
 }
 


### PR DESCRIPTION
- Renamed the global `grpc_addr` variable to `p4ovs_grpc_addr`. Symbols we introduce into the global namespace should be prefixed to make their affinity clear and to reduce the likelihood of collision with other global names.