### PR TITLE
Fix bug that causes the static mac move test to fail

### DIFF
--- a/lib/mac-learning.c
+++ b/lib/mac-learning.c
@@ -456,11 +456,14 @@ bool
 is_mac_learning_update_needed(const struct mac_learning *ml,
                               struct eth_addr src, int vlan,
                               bool is_gratuitous_arp, bool is_bond,
-                              void *in_port)
+                              const void *in_port, bool *is_static_move)
     OVS_REQ_RDLOCK(ml->rwlock)
 {
     struct mac_entry *mac;
+    bool is_port_move;
     int age;
+
+    *is_static_move = false;
 
     if (!mac_learning_may_learn(ml, src, vlan)) {
         return false;
@@ -472,14 +475,13 @@ is_mac_learning_update_needed(const struct mac_learning *ml,
         return true;
     }
 
+    /* Check whether address is on a different port. */
+    is_port_move = mac_entry_get_port(ml, mac) != in_port;
+
     age = mac_entry_age(ml, mac);
     /* If mac is a static entry, then there is no need to update. */
     if (age == MAC_ENTRY_AGE_STATIC_ENTRY) {
-        /* Coverage counter to increment when a packet with same
-         * static-mac appears on a different port. */
-        if (mac_entry_get_port(ml, mac) != in_port) {
-            COVERAGE_INC(mac_learning_static_none_move);
-        }
+        *is_static_move = is_port_move;
         return false;
     }
 
@@ -500,7 +502,7 @@ is_mac_learning_update_needed(const struct mac_learning *ml,
         }
     }
 
-    return mac_entry_get_port(ml, mac) != in_port /* ofbundle */;
+    return is_port_move;
 }
 
 /* Updates MAC learning table 'ml' given that a packet matching 'src' was
@@ -568,7 +570,8 @@ mac_learning_update(struct mac_learning *ml, struct eth_addr src,
                     void *in_port)
     OVS_EXCLUDED(ml->rwlock)
 {
-    bool need_update;
+    bool is_static_move = false;
+    bool need_update = false;
     bool updated = false;
 
     /* Don't learn the OFPP_NONE port. */
@@ -576,8 +579,14 @@ mac_learning_update(struct mac_learning *ml, struct eth_addr src,
         /* First try the common case: no change to MAC learning table. */
         ovs_rwlock_rdlock(&ml->rwlock);
         need_update = is_mac_learning_update_needed(ml, src, vlan,
-                                                    is_gratuitous_arp, is_bond,
-                                                    in_port);
+                                                    is_gratuitous_arp,
+                                                    is_bond, in_port,
+                                                    &is_static_move);
+        if (is_static_move) {
+            /* Coverage counter to increment when a packet with same
+             * static-mac appears on a different port. */
+            COVERAGE_INC(mac_learning_static_none_move);
+        }
         ovs_rwlock_unlock(&ml->rwlock);
 
         if (need_update) {

--- a/lib/mac-learning.h
+++ b/lib/mac-learning.h
@@ -230,11 +230,10 @@ bool mac_learning_may_learn(const struct mac_learning *ml,
                             const struct eth_addr src_mac,
                             uint16_t vlan)
     OVS_REQ_RDLOCK(ml->rwlock);
-bool
-is_mac_learning_update_needed(const struct mac_learning *ml,
-                              struct eth_addr src, int vlan,
-                              bool is_gratuitous_arp, bool is_bond,
-                              void *in_port)
+bool is_mac_learning_update_needed(const struct mac_learning *ml,
+                                   struct eth_addr src, int vlan,
+                                   bool is_gratuitous_arp, bool is_bond,
+                                   const void *in_port, bool *is_static_move)
     OVS_REQ_RDLOCK(ml->rwlock);
 struct mac_entry *mac_learning_insert(struct mac_learning *ml,
                                       const struct eth_addr src,

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -3293,11 +3293,12 @@ xlate_normal(struct xlate_ctx *ctx)
 #if defined(P4OVS)
         bool is_static_move = false;
         need_update = is_mac_learning_update_needed(ctx->xbridge->ml,
-                                                    flow->dl_src, vlan,
-                                                    is_grat_arp,
+                                                    flow->dl_src,
+                                                    vlan, is_grat_arp,
                                                     in_xbundle->bond != NULL,
                                                     in_xbundle->ofbundle,
                                                     &is_static_move);
+        /* ignore is_static_move */
 #endif
         // The function below calls mac_learning_insert
         update_learning_table(ctx, in_xbundle, flow->dl_src, vlan,

--- a/ofproto/ofproto-dpif-xlate.c
+++ b/ofproto/ofproto-dpif-xlate.c
@@ -3198,17 +3198,20 @@ update_ip_mac_map_info(const struct flow *flow,
         return -1;
     }
 
-    memcpy(ip_mac_map_info->src_mac_addr, flow->dl_src.ea, sizeof(ip_mac_map_info->src_mac_addr));
-    memcpy(ip_mac_map_info->dst_mac_addr, flow->dl_dst.ea, sizeof(ip_mac_map_info->dst_mac_addr));
+    memcpy(ip_mac_map_info->src_mac_addr, flow->dl_src.ea,
+           sizeof(ip_mac_map_info->src_mac_addr));
+    memcpy(ip_mac_map_info->dst_mac_addr, flow->dl_dst.ea,
+           sizeof(ip_mac_map_info->dst_mac_addr));
 
-    //Program the entiry only for an ARP response where we have valid IP's and MAC for both src and dst
+    // Program the entry only for an ARP response where we have valid IPs
+    // and MAC for both src and dst.
     if (valid_ip_addr(flow->nw_src) && !eth_addr_is_broadcast(flow->dl_src) &&
-       valid_ip_addr(flow->nw_dst) && !eth_addr_is_broadcast(flow->dl_dst)) {
-       ip_mac_map_info->src_ip_addr.family = AF_INET;
-       ip_mac_map_info->src_ip_addr.ip.v4addr.s_addr = flow->nw_src;
+        valid_ip_addr(flow->nw_dst) && !eth_addr_is_broadcast(flow->dl_dst)) {
+        ip_mac_map_info->src_ip_addr.family = AF_INET;
+        ip_mac_map_info->src_ip_addr.ip.v4addr.s_addr = flow->nw_src;
 
-       ip_mac_map_info->dst_ip_addr.family = AF_INET;
-       ip_mac_map_info->dst_ip_addr.ip.v4addr.s_addr = flow->nw_dst;
+        ip_mac_map_info->dst_ip_addr.family = AF_INET;
+        ip_mac_map_info->dst_ip_addr.ip.v4addr.s_addr = flow->nw_dst;
     }
 
     return -1;
@@ -3221,10 +3224,10 @@ xlate_normal(struct xlate_ctx *ctx)
 {
     struct flow_wildcards *wc = ctx->wc;
     struct flow *flow = &ctx->xin->flow;
-#if defined(P4OVS)
-    bool is_mac_learn_required = false;
-#endif
     struct xbundle *in_xbundle;
+#if defined(P4OVS)
+    bool need_update = false;
+#endif
     struct xport *in_port;
     struct mac_entry *mac;
     void *mac_port;
@@ -3288,18 +3291,21 @@ xlate_normal(struct xlate_ctx *ctx)
         && in_port && in_port->pt_mode != NETDEV_PT_LEGACY_L3
     ) {
 #if defined(P4OVS)
-        is_mac_learn_required = is_mac_learning_update_needed(ctx->xbridge->ml,
-                                flow->dl_src, vlan,is_grat_arp,
-                                in_xbundle->bond != NULL,
-                                in_xbundle->ofbundle);
+        bool is_static_move = false;
+        need_update = is_mac_learning_update_needed(ctx->xbridge->ml,
+                                                    flow->dl_src, vlan,
+                                                    is_grat_arp,
+                                                    in_xbundle->bond != NULL,
+                                                    in_xbundle->ofbundle,
+                                                    &is_static_move);
 #endif
-        //The function below calls mac_learning_insert
+        // The function below calls mac_learning_insert
         update_learning_table(ctx, in_xbundle, flow->dl_src, vlan,
                               is_grat_arp);
     }
 
 #if defined(P4OVS)
-    if (is_mac_learn_required) {
+    if (need_update) {
        /* Dynamic MAC is learnt, program P4 forwarding table */
        struct xport *ovs_port = get_ofp_port(in_xbundle->xbridge,
                                              flow->in_port.ofp_port);


### PR DESCRIPTION
### Background

The `static-mac mac moves` test fails against the P4-enabled build of OVS because the `mac_learning_static_none_move` counter is `2` instead of `1`.

### Analysis

I tracked the issue to a side effect of `is_mac_learning_update_needed()`: in addition to determining whether a MAC Learning update needs to be made, it increments a global counter if the learning request being processed is for a static MAC address that was received on a port other than the one specified in the MAC table entry (a "static mac move").

Originally, the only call to `is_mac_learning_update_needed()` was from `mac_learning_update()`. The P4 changes added a second call to the function, in `xlate_normal()`. As a result, the counter is incremented twice when a static mac move is detected.

### Resolution

`is_mac_learning_update_needed()` is primarily a query function. This is what its name suggests. Query functions should not, as a rule,  affect the state of the system.

I chose to fix the problem by removing the counter increment and having the function return two values: a Boolean indicating whether the mac address should be learned, and a second Boolean indicating whether the request was a static mac move.  (A more general solution would be to make the second value an enum indicating the reason the the update was unnecessary, but this seemed like overdesign.)

I then modified the two calling routines to provide a Boolean variable to receive the second value. `mac_learning_update()` increments the mac-move counter if the returned variable is True. `xlate_normal()` ignores the returned value.

With this change in place, the test no longer fails.