### PR TITLE
Fix bad escape sequences in Python strings

### DIFF
--- a/build-aux/extract-ofp-actions
+++ b/build-aux/extract-ofp-actions
@@ -119,10 +119,10 @@ def extract_ofp_actions(fn, definitions):
             if line.startswith('/*') or not line or line.isspace():
                 fatal("unexpected syntax within action")
             comment += ' %s' % line.lstrip('* \t').rstrip(' \t\r\n')
-        comment = re.sub('\[[^]]*\]', '', comment)
+        comment = re.sub(r'\[[^]]*\]', '', comment)
         comment = comment[:-2].rstrip()
 
-        m = re.match('([^:]+):\s+(.*)$', comment)
+        m = re.match(r'([^:]+):\s+(.*)$', comment)
         if not m:
             fatal("unexpected syntax between actions")
 

--- a/build-aux/extract-ofp-errors
+++ b/build-aux/extract-ofp-errors
@@ -241,19 +241,19 @@ def extract_ofp_errors(fn):
             comment += ' %s' % line.lstrip('* \t').rstrip(' \t\r\n')
         comment = comment[:-2].rstrip()
 
-        m = re.match('Expected: (.*)\.$', comment)
+        m = re.match(r'Expected: (.*)\.$', comment)
         if m:
             expected_errors[m.group(1)] = (fileName, lineNumber)
             continue
 
-        m = re.match('((?:.(?!\.  ))+.)\.\s+(.*)$', comment)
+        m = re.match(r'((?:.(?!\.  ))+.)\.\s+(.*)$', comment)
         if not m:
             fatal("unexpected syntax between errors")
 
         dsts, comment = m.groups()
 
         getLine()
-        m = re.match('\s+(?:OFPERR_([A-Z0-9_]+))(\s*=\s*OFPERR_OFS)?,',
+        m = re.match(r'\s+(?:OFPERR_([A-Z0-9_]+))(\s*=\s*OFPERR_OFS)?,',
                      line)
         if not m:
             fatal("syntax error expecting OFPERR_ enum value")
@@ -262,7 +262,7 @@ def extract_ofp_errors(fn):
         if enum in names:
             fatal("%s specified twice" % enum)
 
-        comments.append(re.sub('\[[^]]*\]', '', comment))
+        comments.append(re.sub(r'\[[^]]*\]', '', comment))
         names.append(enum)
 
         for dst in dsts.split(', '):

--- a/build-aux/extract-ofp-fields
+++ b/build-aux/extract-ofp-fields
@@ -318,9 +318,9 @@ def group_xml_to_nroff(group_node, fields):
         '.SS "Summary:"\n',
         ".TS\n",
         "tab(;);\n",
-        "l l l l l l l.\n",
+        "l l l l l l.\n",
         "Name;Bytes;Mask;RW?;Prereqs;NXM/OXM Support\n",
-        "\_;\_;\_;\_;\_;\_\n",
+        r"\_;\_;\_;\_;\_;\_\n",
     ]
     content += summary
     content += [".TE\n"]
@@ -332,7 +332,7 @@ def make_oxm_classes_xml(document):
     s = """tab(;);
 l l l.
 Prefix;Vendor;Class
-\_;\_;\_
+\\_;\\_;\\_
 """
     for key in sorted(OXM_CLASSES, key=OXM_CLASSES.get):
         vendor, class_, class_type = OXM_CLASSES.get(key)
@@ -374,7 +374,7 @@ def make_ovs_fields(meta_flow_h, meta_flow_xml):
         """\
 '\\" tp
 .\\" -*- mode: troff; coding: utf-8 -*-
-.TH "ovs\-fields" 7 "%s" "Open vSwitch" "Open vSwitch Manual"
+.TH "ovs\\-fields" 7 "%s" "Open vSwitch" "Open vSwitch Manual"
 .fp 5 L CR              \\" Make fixed-width font available as \\fL.
 .de ST
 .  PP
@@ -404,7 +404,7 @@ def make_ovs_fields(meta_flow_h, meta_flow_xml):
 ..
 .if \\n[.g] .mso www.tmac
 .SH NAME
-ovs\-fields \- protocol header fields in OpenFlow and Open vSwitch
+ovs\\-fields \\- protocol header fields in OpenFlow and Open vSwitch
 .
 .PP
 """

--- a/build-aux/extract-ofp-msgs
+++ b/build-aux/extract-ofp-msgs
@@ -115,7 +115,7 @@ def extract_ofp_msgs(output_file_name):
         number = int(number)
 
         get_line()
-        m = re.match('\s+(?:OFPRAW_%s)(\d*)_([A-Z0-9_]+),?$' % type_,
+        m = re.match(r'\s+(?:OFPRAW_%s)(\d*)_([A-Z0-9_]+),?$' % type_,
                      line)
         if not m:
             fatal("syntax error expecting OFPRAW_ enum")

--- a/ovsdb/ovsdb-doc
+++ b/ovsdb/ovsdb-doc
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 # Copyright (c) 2010, 2011, 2012, 2013, 2014, 2015, 2020 Nicira, Inc.
+# Copyright (c) 2024 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -239,7 +240,7 @@ Purpose
     if erFile:
         s += """
 .\\" check if in troff mode (TTY)
-.if t \{
+.if t \\{
 .bp
 .SH "TABLE RELATIONSHIPS"
 .PP


### PR DESCRIPTION
- Some of the Python scripts contain strings with ill-formed escape sequences, which generate errors in newer versions of the Python interpreter. This CL addresses the issue.